### PR TITLE
Refactor socket handlers

### DIFF
--- a/client/src/GameContext.js
+++ b/client/src/GameContext.js
@@ -149,6 +149,11 @@ export default function GameContext({ children }) {
             });
         });
 
+        socketRef.current.on('room_missing', () => {
+            localStorage.removeItem('room_code');
+            resetState();
+        });
+
         socketRef.current.on('task_locations', (data) => {
             setTaskLocations(data)
         })

--- a/client/src/GameContext.js
+++ b/client/src/GameContext.js
@@ -14,6 +14,7 @@ export default function GameContext({ children }) {
         username: '',
         playerId: localStorage.getItem('player_id') || '',
     });
+    const [roomCode, setRoomCode] = useState(localStorage.getItem('room_code') || '');
 
     // united states
     const [gameState, setGameState] = useState({}); // <--- USE this PLEASE we need to refactor this shit
@@ -55,6 +56,7 @@ export default function GameContext({ children }) {
             username: '',
             playerId: localStorage.getItem('player_id') || '',
         })
+        setRoomCode(localStorage.getItem('room_code') || '')
         setTask(undefined)
         setRunning(false)
         setCrewScore(0);
@@ -143,6 +145,7 @@ export default function GameContext({ children }) {
             setConnected(true);
             socketRef.current.emit('rejoin', {
                 player_id: playerState.playerId,
+                room: roomCode,
             });
         });
 
@@ -281,6 +284,10 @@ export default function GameContext({ children }) {
                 localStorage.setItem('player_id', data.player_id);
                 setPlayerState(prevState => ({ ...prevState, playerId: data.player_id }));
             }
+            if (data && data.room) {
+                localStorage.setItem('room_code', data.room);
+                setRoomCode(data.room);
+            }
         });
 
         socketRef.current.on('game_data', (data) => {
@@ -352,6 +359,8 @@ export default function GameContext({ children }) {
     const contextValue = useMemo(() => ({
         playerState,
         setPlayerState,
+        roomCode,
+        setRoomCode,
         gameState,
         setGameState,
         socket: socketRef.current,
@@ -425,7 +434,9 @@ export default function GameContext({ children }) {
         showSusPage,
         killCooldown,
         activeCards,
-        modalOpen
+        modalOpen,
+        roomCode,
+        setRoomCode
     ]);
 
     return (

--- a/client/src/GameContext.js
+++ b/client/src/GameContext.js
@@ -11,7 +11,7 @@ const DataContext = createContext();
 
 export default function GameContext({ children }) {
     const [playerState, setPlayerState] = useState({
-        username: '',
+        username: localStorage.getItem('username') || '',
         playerId: localStorage.getItem('player_id') || '',
     });
     const [roomCode, setRoomCode] = useState(localStorage.getItem('room_code') || '');
@@ -53,7 +53,7 @@ export default function GameContext({ children }) {
         setConnected(false)
         setPlayers([])
         setPlayerState({
-            username: '',
+            username: localStorage.getItem('username') || '',
             playerId: localStorage.getItem('player_id') || '',
         })
         setRoomCode(localStorage.getItem('room_code') || '')
@@ -313,6 +313,7 @@ export default function GameContext({ children }) {
                         me = parsedPlayers.find((player) => player.player_id === localStorage.getItem('player_id'))
                         if (me) {
                             setPlayerState(me)
+                            localStorage.setItem('username', me.username)
                             console.log(me)
                         } else {
                             console.log("not found")

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -3,7 +3,7 @@ import { ChevronLeft } from 'lucide-react';
 import { DataContext } from '../GameContext';
 
 function LoginPage() {
-    const [username, setUsername] = useState('');
+    const [username, setUsername] = useState(localStorage.getItem('username') || '');
     const { setPlayerState, socket, setTaskEntry, roomCode, setRoomCode } = useContext(DataContext);
     const [localRoom, setLocalRoom] = useState(roomCode);
 
@@ -16,6 +16,7 @@ function LoginPage() {
         e.preventDefault();
 
         setPlayerState(prevState => ({ ...prevState, username: username }));
+        localStorage.setItem('username', username);
         let playerId = localStorage.getItem('player_id');
 
         socket.emit('join', { player_id: playerId, username: username, room: localRoom });

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -4,7 +4,8 @@ import { DataContext } from '../GameContext';
 
 function LoginPage() {
     const [username, setUsername] = useState('');
-    const { setPlayerState, socket, setTaskEntry } = useContext(DataContext);
+    const { setPlayerState, socket, setTaskEntry, roomCode, setRoomCode } = useContext(DataContext);
+    const [localRoom, setLocalRoom] = useState(roomCode);
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -17,8 +18,21 @@ function LoginPage() {
         setPlayerState(prevState => ({ ...prevState, username: username }));
         let playerId = localStorage.getItem('player_id');
 
-        socket.emit('join', { player_id: playerId, username: username });
+        socket.emit('join', { player_id: playerId, username: username, room: localRoom });
     };
+
+    const handleCreateRoom = () => {
+        socket.emit('create_room');
+    };
+
+    useEffect(() => {
+        socket.on('room_created', (data) => {
+            setRoomCode(data.room);
+            setLocalRoom(data.room);
+            localStorage.setItem('room_code', data.room);
+        });
+        return () => socket.off('room_created');
+    }, [socket]);
 
     const handleEnterTasks = () => {
         setTaskEntry(true)
@@ -59,6 +73,25 @@ function LoginPage() {
                             required
                         />
                     </div>
+                    {!localRoom && (
+                        <div className="mb-4">
+                            <label htmlFor="room" className="block text-gray-300 mb-2">
+                                Room Code
+                            </label>
+                            <input
+                                type="text"
+                                id="room"
+                                value={localRoom}
+                                onChange={(e) => setLocalRoom(e.target.value.toUpperCase())}
+                                className="w-full px-4 py-2 border border-gray-500 rounded-lg bg-gray-600 text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400 transition-colors"
+                                placeholder="XXXX"
+                            />
+                            <button type="button" onClick={handleCreateRoom} className="mt-2 w-full bg-gray-600 text-white py-2 px-4 rounded-lg hover:bg-gray-700">Create Room</button>
+                        </div>
+                    )}
+                    {localRoom && (
+                        <p className="text-center text-gray-300 mb-4">Room: {localRoom}</p>
+                    )}
                     <button
                         type="submit"
                         className="w-full bg-indigo-600 text-white py-2 px-4 rounded-lg hover:bg-indigo-700 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-400 transform hover:scale-105"

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -8,6 +8,10 @@ function LoginPage() {
     const [localRoom, setLocalRoom] = useState(roomCode);
 
     useEffect(() => {
+        setLocalRoom(roomCode);
+    }, [roomCode]);
+
+    useEffect(() => {
         window.scrollTo(0, 0);
       }, []);
     

--- a/client/src/pages/PlayersPage.js
+++ b/client/src/pages/PlayersPage.js
@@ -7,7 +7,7 @@ import PlayerCard from "../components/PlayerCard";
 import { ChevronLeft } from 'lucide-react';
 
 export default function PlayersPage() {
-    const { players, socket, setMessage, setAudio, running, setTaskEntry } = useContext(DataContext);
+    const { players, socket, setMessage, setAudio, running, setTaskEntry, playerState } = useContext(DataContext);
 
     useEffect(() => {
         window.scrollTo(0, 0)
@@ -26,7 +26,7 @@ export default function PlayersPage() {
     }
 
     function startGame() {
-        socket.emit('start_game', {});
+        socket.emit('start_game', { player_id: playerState.playerId });
 
     }
 

--- a/server/app.py
+++ b/server/app.py
@@ -40,10 +40,8 @@ eventlet.monkey_patch()
 from flask import Flask
 from flask_socketio import SocketIO
 from flask_cors import CORS
-from assets.game import Game
 from assets.sonosHandler import SonosController
 from assets.utils import setup_logging, get_local_ip, write_ip_to_file
-from assets.taskHandler import TaskHandler
 from socket_handlers import register_socket_handlers
 
 logger = setup_logging()
@@ -58,14 +56,23 @@ speaker = SonosController(enabled=sonos_enabled, default_volume=speaker_volume, 
 if sonos_enabled:
     speaker.play_sound("theme")
 
-taskHandler = TaskHandler(locations)
-game = Game(socketio, taskHandler, speaker, task_ratio, meltdown_time, code_percent, locations, vote_time, card_draw_probability, number_of_imposters, starting_cards)
 
 @app.route('/')
 def index():
     return "<h1>You shouldn't see this. Please change your port from :5000 to :3000</h1>"
 
-register_socket_handlers(socketio, game, taskHandler, speaker, locations, logger)
+config = {
+    'task_ratio': task_ratio,
+    'meltdown_time': meltdown_time,
+    'code_percent': code_percent,
+    'locations': locations,
+    'vote_time': vote_time,
+    'card_draw_probability': card_draw_probability,
+    'number_of_imposters': number_of_imposters,
+    'starting_cards': starting_cards,
+}
+
+register_socket_handlers(socketio, speaker, config, logger)
 
 if __name__ == '__main__':
     local_ip = get_local_ip()

--- a/server/app.py
+++ b/server/app.py
@@ -37,13 +37,14 @@ ignore_bedroom_speakers = True
 
 import eventlet
 eventlet.monkey_patch()
-from flask import Flask, request
-from flask_socketio import SocketIO, emit
+from flask import Flask
+from flask_socketio import SocketIO
 from flask_cors import CORS
 from assets.game import Game
 from assets.sonosHandler import SonosController
-from assets.utils import *
-from assets.taskHandler import *
+from assets.utils import setup_logging, get_local_ip, write_ip_to_file
+from assets.taskHandler import TaskHandler
+from socket_handlers import register_socket_handlers
 
 logger = setup_logging()
 
@@ -60,223 +61,11 @@ if sonos_enabled:
 taskHandler = TaskHandler(locations)
 game = Game(socketio, taskHandler, speaker, task_ratio, meltdown_time, code_percent, locations, vote_time, card_draw_probability, number_of_imposters, starting_cards)
 
-def sendPlayerList(action='player_list'):
-    logger.info("Sending player list to all clients")
-    player_list = [player.to_json() for player in game.players]
-    logger.debug(f"Player List: {player_list}")
-    emit('game_data', {'action': action, 'list': player_list}, broadcast=True, json=True)
-
 @app.route('/')
 def index():
     return "<h1>You shouldn't see this. Please change your port from :5000 to :3000</h1>"
 
-@socketio.on('connect')
-def handle_connect():
-    logger.info(f'Client connected: {request.sid}')
-    emit('task_locations', locations, json=True)
-
-    if game.game_running:
-        emit("game_start")
-        emit("crew_score", {"score": game.crew_score})
-        emit("task_goal", game.taskGoal)
-
-        if game.end_state:
-            logger.info(f"Game over: {game.end_state}")
-            emit("end_game", game.end_state)
-        if len(game.card_deck.active_cards) > 0:
-            game.card_deck.emit_active_cards()
-
-        if game.active_hack > 0:
-            emit("hack", game.active_hack)
-            logger.debug(f"Active hack: {game.active_hack}")
-        if game.meeting:
-            print(game.meeting.time_left)
-            emit("meeting", game.meeting.to_json())
-            if game.meeting.stage == 'voting':
-                game.meeting.emit_vote_counts()
-            logger.debug("Meeting is active")
-
-@socketio.on('rejoin')
-def handleJoin(data):
-    player = game.getPlayerById(data.get('player_id'))
-    if player:
-        logger.info("Existing player rejoining...")
-        player.sid = request.sid
-        sendPlayerList("rejoin")
-
-        if game.denied_location:
-            emit('active_denial', game.denied_location)
-
-        if player.meltdown_code and game.active_meltdown:
-            emit("meltdown_code", player.meltdown_code, to=player.sid)
-            logger.debug(f"Sent meltdown code to player {player.player_id}")
-
-        if player.get_task():
-            logger.info("Sending task to player")
-            emit("task", {"task": player.get_task()}, to=player.sid)
-
-@socketio.on('add_task') # this should use an api and not a socket
-def addTask(data):
-    print(data)
-    taskHandler.add_task(data)
-
-@socketio.on("complete_task")
-def handleTaskComplete(data):
-    player = game.getPlayerById(data.get('player_id'))
-    if player and len(taskHandler.tasks) > 0:
-        game.crew_score += 1
-        emit("crew_score", {"score": game.crew_score}, broadcast=True)
-        logger.info(f"Player {player.player_id} completed a task. Crew score: {game.crew_score}")
-        player.task = game.getTask()
-        emit("task", {"task": player.task}, to=player.sid)
-        logger.debug(f"Assigned new task to player {player.player_id}: {player.task}")
-    elif player and len(taskHandler.tasks) == 0:
-        player.task = None
-        emit("task", {"task": "No More Tasks"}, to=player.sid)
-        logger.info(f"No more tasks available. Informed player {player.player_id}")
-
-def handleHack(hack_length=30):
-    if not game.active_hack and not game.meeting:
-        logger.info(f"Hack initiated. ")
-        game.start_hack(hack_length)
-        speaker.play_sound('hack')
-        logger.debug("Hack started with a duration of 30 seconds")
-
-@socketio.on("play_card")
-def playCard(data):
-    print(data)
-    player = game.getPlayerById(data.get('player_id'))
-    card = player.get_card(data.get('card_id'))
-    if card:
-        card.play_card(player)
-
-@socketio.on("meeting")
-def handleMeeting(data):
-    if not game.meeting:
-        speaker.play_sound("meeting")
-        player = game.getPlayerById(data.get('player_id'))
-        game.start_meeting(player)
-
-        # emit("meeting", broadcast=True)
-        # game.meeting = True
-        logger.info("Meeting started")
-
-@socketio.on("ready")
-def handleReady(data):
-    player = game.getPlayerById(data.get('player_id'))
-    player.ready = True
-    sendPlayerList()
-    game.try_start_voting() # only starts if all players are ready
-
-@socketio.on("vote")
-def handleVote(data):
-    voting_player = game.getPlayerById(data.get('player_id'))
-    voted_for = game.getPlayerById(data.get('votedFor'))
-    game.meeting.register_vote(voting_player, voted_for)
-
-@socketio.on("veto")
-def handleVote(data):
-    voting_player = game.getPlayerById(data.get('player_id'))
-    game.meeting.register_vote(voting_player, veto=True)
-        
-
-@socketio.on('end_meeting')
-def handleEndMeeting():
-    if game.meeting:
-        emit("end_meeting", broadcast=True)
-        game.meeting = False
-        logger.info("Meeting ended")
-
-
-@socketio.on('meltdown')
-def handleMeltdown():
-    game.start_meltdown()
-    ## add card draw?
-    logger.warning("Meltdown occurred.")
-
-@socketio.on("pin_entry")
-def handlePinEntry(data):
-    logger.info("Pin entered")
-    game.check_pin(data)
-    logger.debug(f"Pin data: {data}")
-
-@socketio.on('player_dead')
-def handleDeath(data):
-    game.kill_player(data.get('player_id'))
-
-@socketio.on('reset')
-def reset_game():
-    for player in game.players:
-        player.reset()
-    sendPlayerList()
-    logger.info("Game has been reset")
-
-@socketio.on('start_game')
-def handle_start(data):
-    if game.game_running:
-        logger.warning("Start game attempted but game is already running")
-        return
-
-    speaker.play_sound("theme")
-    game.game_running = True
-    game.assignRoles()
-    sendPlayerList('start_game')
-    emit("task_goal", game.taskGoal, broadcast=True)
-    logger.info("Game started")
-
-    # Send a different task to each crewmate
-    for player in game.players:
-        if not player.sus and len(taskHandler.tasks) > 0:
-            # gotta change this for impostor power ups 
-            player.task = game.getTask()
-            emit("task", {"task": player.task}, to=player.sid)
-            logger.debug(f"Assigned task to player {player.player_id}: {player.task}")
-
-
-@socketio.on('join')
-def handle_join(data):
-    player_id = data.get('player_id')
-    username = data.get('username')
-    sid = request.sid
-
-    if not username:
-        emit('error', {'message': 'Username is required'}, to=sid)
-        logger.warning(f"Join attempt without username from SID: {sid}")
-        return
-
-    if player_id:
-        player = game.getPlayerById(player_id)
-        if player:
-            # Player reconnected
-            player.sid = sid
-            player.username = username  # Update username on reconnect
-            logger.info(f"Player {player.username} (ID: {player.player_id}) reconnected with new SID: {sid}")
-        else:
-            # Invalid player_id, create new player
-            if game.game_running:
-                logger.warning(f"Join attempt with invalid player_id: {player_id} while game is running")
-                return
-            player = game.addPlayer(sid, username)
-            emit('player_id', {'player_id': player.player_id}, to=sid)
-            logger.info(f"New player {username} joined with new ID {player.player_id}")
-    else:
-        # New player
-        if game.game_running:
-            logger.warning(f"Join attempt without player_id while game is running for username: {username}")
-            return
-        player = game.addPlayer(sid, username)
-        emit('player_id', {'player_id': player.player_id, 'pic': player.pic}, to=sid)
-        logger.info(f"New player {username} joined with ID {player.player_id}")
-
-    sendPlayerList()
-
-@socketio.on('disconnect')
-def handle_disconnect():
-    logger.info(f"Client disconnected: {request.sid}")
-    # Optional: Handle player disconnection logic
-    # player = game.getPlayerBySid(request.sid)
-    # if player:
-    #     sendPlayerList()
+register_socket_handlers(socketio, game, taskHandler, speaker, locations, logger)
 
 if __name__ == '__main__':
     local_ip = get_local_ip()

--- a/server/assets/card.py
+++ b/server/assets/card.py
@@ -17,7 +17,7 @@ class Card:
         self.text = text
         self.card_deck = card_deck
         self.game = card_deck.game
-        self.socket = card_deck.socket
+        self.socketio = card_deck.socketio
         self.id = str(uuid.uuid4())
     
     def __repr__(self):
@@ -35,7 +35,7 @@ class Card:
     def notify_impostors(self, player):
         for other_player in self.game.players:
             if (other_player is not player) and other_player.sus and other_player.alive:
-                send_message_to_player(self.socket, other_player.player_id, f"{player.username} played {self.action}")
+                send_message_to_player(self.socketio, other_player.player_id, f"{player.username} played {self.action}")
 
 
     def play_card(self, player):
@@ -65,7 +65,7 @@ class Card:
                 player.remove_card(self)
                 player.cards.pop(0)
                 card= self.card_deck.draw_card()
-                send_message_to_player(self.socket, player.player_id, f"You drew: {card.action}")
+                send_message_to_player(self.socketio, player.player_id, f"You drew: {card.action}")
                 player.cards.append(card)
 
         elif self.action == 'Shorten Meltdown':
@@ -93,10 +93,10 @@ class Card:
 
 class CardDeck:
 
-    def __init__(self, locations, socket, game):
+    def __init__(self, locations, socketio, game):
         self.discard = []
         self.active_cards = []
-        self.socket = socket
+        self.socketio = socketio
         self.game = game
 
         self.cards = [# CHANGE THESE THEYDONT WORK
@@ -164,7 +164,7 @@ class CardDeck:
         for card in self.active_cards:
             output.append(card.export())
         print(output)
-        self.socket.emit('active_cards', output)
+        self.socketio.emit('active_cards', output)
 
 
 

--- a/server/assets/game.py
+++ b/server/assets/game.py
@@ -13,7 +13,7 @@ from assets.utils import *
 
 class Game:
 
-    def __init__(self, socketio, task_handler, speaker, task_ratio, meltdown_time, code_percent, locations, vote_time, card_draw_probability, numImposters, starting_cards):
+    def __init__(self, socketio, task_handler, speaker, task_ratio, meltdown_time, code_percent, locations, vote_time, card_draw_probability, numImposters, starting_cards, room=None):
         self.players = []
         self.task_handler = task_handler
         self.crew_score = 0
@@ -34,6 +34,7 @@ class Game:
         self.card_deck = CardDeck(locations, socketio, self)
         self.active_cards = []
         self.card_draw_probability = card_draw_probability
+        self.room = room
 
         # Tasks per player
         self.task_ratio = task_ratio
@@ -58,21 +59,21 @@ class Game:
     def meltdown(self): # call when meltdown fails
         self.active_meltdown = None
         self.end_state = "meltdown_fail"
-        self.socketio.emit("end_game", self.end_state)
+        self.socketio.emit("end_game", self.end_state, room=self.room)
 
         if self.speaker:
             self.speaker.play_sound("sus_victory")
 
     def emit_player_list(self):
         player_list = [player.to_json() for player in self.players]
-        self.socketio.emit('game_data', {'action': 'player_list', 'list': player_list})
+        self.socketio.emit('game_data', {'action': 'player_list', 'list': player_list}, room=self.room)
 
     def start_hack(self, duration):
         if self.active_hack > 0:
             return
         self.speaker.play_sound('hack')
         self.active_hack = duration
-        self.socketio.emit("hack", duration, broadcast=True)
+        self.socketio.emit("hack", duration, room=self.room)
 
         # Start a background thread to handle the countdown
         Thread(target=self._hack_countdown).start()
@@ -174,7 +175,7 @@ class Game:
     def start_meeting(self, player_who_started_it):
         self.meeting = Meeting(self.vote_time, self.socketio, player_who_started_it, self)
         self.speaker.play_sound('meeting')
-        self.socketio.emit("meeting", self.meeting.to_json())
+        self.socketio.emit("meeting", self.meeting.to_json(), room=self.room)
 
     def get_num_living_players(self):
         living_players = 0
@@ -210,7 +211,7 @@ class Game:
             if self.numCrew <= 0:
                 self.end_state = 'sus_victory'
                 self.speaker.play_sound('sus_victory')
-                self.socketio.emit("end_game", self.end_state)
+                self.socketio.emit("end_game", self.end_state, room=self.room)
                 return
     
             
@@ -219,7 +220,7 @@ class Game:
             if self.numImposters <= 0:
                 self.end_state = 'victory'
                 self.speaker.play_sound('crew_victory')
-                self.socketio.emit("end_game", self.end_state)
+                self.socketio.emit("end_game", self.end_state, room=self.room)
                 return
                 
         if self.meeting:

--- a/server/assets/game.py
+++ b/server/assets/game.py
@@ -7,13 +7,13 @@ from assets.card import *
 from assets.meeting import *
 import time
 from threading import Thread
-from flask_socketio import emit
+
 from assets.utils import *
 
 
 class Game:
 
-    def __init__(self, socket, task_handler, speaker, task_ratio, meltdown_time, code_percent, locations, vote_time, card_draw_probability, numImposters, starting_cards):
+    def __init__(self, socketio, task_handler, speaker, task_ratio, meltdown_time, code_percent, locations, vote_time, card_draw_probability, numImposters, starting_cards):
         self.players = []
         self.task_handler = task_handler
         self.crew_score = 0
@@ -27,11 +27,11 @@ class Game:
         self.taskGoal = None
         self.completed_tasks = 0
         self.backgrounds = list(range(0, 16 + 1))  
-        self.socket = socket
+        self.socketio = socketio
         self.end_state = None
         self.speaker = speaker
         self.denied_location = None
-        self.card_deck = CardDeck(locations, socket, self)
+        self.card_deck = CardDeck(locations, socketio, self)
         self.active_cards = []
         self.card_draw_probability = card_draw_probability
 
@@ -44,7 +44,7 @@ class Game:
 
     def start_meltdown(self):
         self.speaker.loop_sound("meltdown", self.meltdown_time - self.meltdown_time_mod)
-        self.active_meltdown = Meltdown(self.players, self.meltdown_time - self.meltdown_time_mod, self.socket, self.speaker, self.code_percent)
+        self.active_meltdown = Meltdown(self.players, self.meltdown_time - self.meltdown_time_mod, self.socketio, self.speaker, self.code_percent)
         self.meltdown_time_mod = 0
         for card in self.active_cards:
             if card.action == 'reduce_meltdown':
@@ -58,21 +58,21 @@ class Game:
     def meltdown(self): # call when meltdown fails
         self.active_meltdown = None
         self.end_state = "meltdown_fail"
-        self.socket.emit("end_game", self.end_state)
+        self.socketio.emit("end_game", self.end_state)
 
         if self.speaker:
             self.speaker.play_sound("sus_victory")
 
     def emit_player_list(self):
         player_list = [player.to_json() for player in self.players]
-        self.socket.emit('game_data', {'action': 'player_list', 'list': player_list})
+        self.socketio.emit('game_data', {'action': 'player_list', 'list': player_list})
 
     def start_hack(self, duration):
         if self.active_hack > 0:
             return
         self.speaker.play_sound('hack')
         self.active_hack = duration
-        emit("hack", duration, broadcast=True)
+        self.socketio.emit("hack", duration, broadcast=True)
 
         # Start a background thread to handle the countdown
         Thread(target=self._hack_countdown).start()
@@ -115,7 +115,7 @@ class Game:
                 card = self.card_deck.draw_card(probability)
                 if card:
                     self.players[i].cards.append(card)
-                    send_message_to_player(self.socket, self.players[i].player_id, f"You drew {card.action}")
+                    send_message_to_player(self.socketio, self.players[i].player_id, f"You drew {card.action}")
 
         self.emit_player_list()
 
@@ -168,13 +168,13 @@ class Game:
         self.backgrounds = list(range(0, 16 + 1))  
         self.end_state = None
         self.denied_location = None
-        self.card_deck = CardDeck(self.locations)
+        self.card_deck = CardDeck(self.locations, self.socketio, self)
         self.task_handler.reset()
 
     def start_meeting(self, player_who_started_it):
-        self.meeting = Meeting(self.vote_time, self.socket, player_who_started_it, self)
+        self.meeting = Meeting(self.vote_time, self.socketio, player_who_started_it, self)
         self.speaker.play_sound('meeting')
-        self.socket.emit("meeting", self.meeting.to_json())
+        self.socketio.emit("meeting", self.meeting.to_json())
 
     def get_num_living_players(self):
         living_players = 0
@@ -210,7 +210,7 @@ class Game:
             if self.numCrew <= 0:
                 self.end_state = 'sus_victory'
                 self.speaker.play_sound('sus_victory')
-                self.socket.emit("end_game", self.end_state)
+                self.socketio.emit("end_game", self.end_state)
                 return
     
             
@@ -219,7 +219,7 @@ class Game:
             if self.numImposters <= 0:
                 self.end_state = 'victory'
                 self.speaker.play_sound('crew_victory')
-                self.socket.emit("end_game", self.end_state)
+                self.socketio.emit("end_game", self.end_state)
                 return
                 
         if self.meeting:

--- a/server/assets/meeting.py
+++ b/server/assets/meeting.py
@@ -22,10 +22,10 @@ class Meeting:
     def start_voting(self):
         if self.game.get_num_living_players() <= 1:
             self.game.end_state = 'sus_victory'
-            self.socketio.emit("end_game", self.game.end_state)
+            self.socketio.emit("end_game", self.game.end_state, room=self.game.room)
             return
         self.stage = 'voting'
-        self.socketio.emit("meeting", self.to_json())
+        self.socketio.emit("meeting", self.to_json(), room=self.game.room)
         self.speaker.play_sound('hurry')
         Thread(target=self._vote_countdown).start()
     
@@ -78,7 +78,7 @@ class Meeting:
         veto_count = len(self.veto_votes)
 
         print(f"Vote Summary: {vote_summary}, Veto Votes: {veto_count}")
-        self.socketio.emit("vote_update", {"votes": vote_summary, "vetoVotes": veto_count})
+        self.socketio.emit("vote_update", {"votes": vote_summary, "vetoVotes": veto_count}, room=self.game.room)
 
     def check_veto_threshold(self):
         """
@@ -122,7 +122,7 @@ class Meeting:
             self.reason = 'veto'
 
             print("Meeting ended early due to veto threshold...")
-            self.socketio.emit("meeting", self.to_json())
+            self.socketio.emit("meeting", self.to_json(), room=self.game.room)
             self.speaker.play_sound('veto')
         else:
         # Regular meeting ending, determine who was voted out
@@ -137,7 +137,7 @@ class Meeting:
             self.reason = 'votes'
             self.votes = self.compute_vote_counts()
 
-            self.socketio.emit("meeting", self.to_json())
+            self.socketio.emit("meeting", self.to_json(), room=self.game.room)
 
             # draw cards for impostors
             self.game.drawCards(probability=self.game.card_draw_probability)

--- a/server/assets/meeting.py
+++ b/server/assets/meeting.py
@@ -1,15 +1,14 @@
 import json
 from threading import Thread
-from flask_socketio import emit
 import time
 from collections import Counter
 
 class Meeting:
 
-    def __init__(self, vote_time, socket, player_who_started_it, game):
+    def __init__(self, vote_time, socketio, player_who_started_it, game):
         self.stage = 'waiting'
         self.time_left = vote_time
-        self.socket = socket
+        self.socketio = socketio
         self.player_who_started_it = player_who_started_it
         self.game = game
         self.speaker = game.speaker
@@ -23,10 +22,10 @@ class Meeting:
     def start_voting(self):
         if self.game.get_num_living_players() <= 1:
             self.game.end_state = 'sus_victory'
-            self.socket.emit("end_game", self.game.end_state)
+            self.socketio.emit("end_game", self.game.end_state)
             return
         self.stage = 'voting'
-        self.socket.emit("meeting", self.to_json())
+        self.socketio.emit("meeting", self.to_json())
         self.speaker.play_sound('hurry')
         Thread(target=self._vote_countdown).start()
     
@@ -79,7 +78,7 @@ class Meeting:
         veto_count = len(self.veto_votes)
 
         print(f"Vote Summary: {vote_summary}, Veto Votes: {veto_count}")
-        self.socket.emit("vote_update", {"votes": vote_summary, "vetoVotes": veto_count})
+        self.socketio.emit("vote_update", {"votes": vote_summary, "vetoVotes": veto_count})
 
     def check_veto_threshold(self):
         """
@@ -123,7 +122,7 @@ class Meeting:
             self.reason = 'veto'
 
             print("Meeting ended early due to veto threshold...")
-            self.socket.emit("meeting", self.to_json())
+            self.socketio.emit("meeting", self.to_json())
             self.speaker.play_sound('veto')
         else:
         # Regular meeting ending, determine who was voted out
@@ -138,7 +137,7 @@ class Meeting:
             self.reason = 'votes'
             self.votes = self.compute_vote_counts()
 
-            self.socket.emit("meeting", self.to_json())
+            self.socketio.emit("meeting", self.to_json())
 
             # draw cards for impostors
             self.game.drawCards(probability=self.game.card_draw_probability)

--- a/server/assets/meltdown.py
+++ b/server/assets/meltdown.py
@@ -18,7 +18,7 @@ class Meltdown:
     def start_countdown(self):
         """Starts the countdown timer."""
         print(f"Meltdown initiated! {self.time_left} seconds remaining.")
-        self.socketio.emit("codes_needed", self.codes_needed)
+        self.socketio.emit("codes_needed", self.codes_needed, room=self.game.room)
         self.distribute_codes()
         while self.time_left > 0:
             if self.codes_entered >= self.codes_needed:
@@ -26,7 +26,7 @@ class Meltdown:
                 return
             eventlet.sleep(1)  # Asynchronous delay
             self.time_left -= 1
-            self.socketio.emit('meltdown_update', self.time_left)
+            self.socketio.emit('meltdown_update', self.time_left, room=self.game.room)
 
         # If the countdown reaches 0 and the meltdown is still active
         if self.meltdown_active:
@@ -50,18 +50,18 @@ class Meltdown:
         except ValueError:
             # Handle the case where conversion fails
             print("Invalid PIN format. PIN should be a number.")
-            self.socketio.emit("code_incorrect")
+            self.socketio.emit("code_incorrect", room=self.game.room)
             return False
     
         if input_pin in self.valid_pins:
             print("Valid PIN entered!")
             self.valid_pins.remove(input_pin)
             self.codes_entered += 1
-            self.socketio.emit("code_correct", self.codes_needed - self.codes_entered)
+            self.socketio.emit("code_correct", self.codes_needed - self.codes_entered, room=self.game.room)
             return True
     
         print("Invalid PIN")
-        self.socketio.emit("code_incorrect")
+        self.socketio.emit("code_incorrect", room=self.game.room)
         return False
 
 
@@ -72,7 +72,7 @@ class Meltdown:
             if self.game:
                 self.game.active_meltdown = None
             self.speaker.play_sound("meltdown_over")
-            self.socketio.emit('meltdown_end')
+            self.socketio.emit('meltdown_end', room=self.game.room)
         else:
             print("Meltdown failed!")
             self.speaker.play_sound("meltdown_fail")

--- a/server/assets/utils.py
+++ b/server/assets/utils.py
@@ -55,5 +55,5 @@ def setup_logging():
 
     return logger
 
-def send_message_to_player(socket, player_id, message):
-    socket.emit('message', {'player': player_id, 'message': message})
+def send_message_to_player(socketio, player_id, message):
+    socketio.emit('message', {'player': player_id, 'message': message})

--- a/server/socket_handlers.py
+++ b/server/socket_handlers.py
@@ -71,6 +71,7 @@ def register_socket_handlers(socketio: SocketIO, speaker, config, logger):
         player_id = data.get("player_id")
         room = data.get("room") or player_rooms.get(player_id)
         if not room or room not in rooms:
+            emit("room_missing", to=request.sid)
             return
 
         game = rooms[room]["game"]

--- a/server/socket_handlers.py
+++ b/server/socket_handlers.py
@@ -1,177 +1,249 @@
-# Socket event handlers for the game
+"""Socket event handlers supporting multiple game rooms."""
 
+import random
+import string
 from flask import request
-from flask_socketio import emit, SocketIO
+from flask_socketio import emit, join_room, SocketIO
+
+from assets.game import Game
+from assets.taskHandler import TaskHandler
 
 
-def register_socket_handlers(socketio: SocketIO, game, task_handler, speaker, locations, logger):
+def register_socket_handlers(socketio: SocketIO, speaker, config, logger):
     """Register all socket.io event handlers."""
 
-    def send_player_list(action='player_list'):
-        logger.info("Sending player list to all clients")
-        player_list = [player.to_json() for player in game.players]
-        emit('game_data', {'action': action, 'list': player_list}, broadcast=True, json=True)
+    rooms = {}
+    player_rooms = {}
+    sid_map = {}
+    locations = config["locations"]
 
-    @socketio.on('connect')
-    def handle_connect():
-        logger.info(f'Client connected: {request.sid}')
-        emit('task_locations', locations, json=True)
+    def generate_room_code():
+        return "".join(random.choices(string.ascii_uppercase + string.digits, k=4))
 
-        if game.game_running:
-            emit('game_start')
-            emit('crew_score', {'score': game.crew_score})
-            emit('task_goal', game.taskGoal)
+    def get_game_by_player(player_id):
+        room = player_rooms.get(player_id)
+        if room:
+            return rooms.get(room)["game"], room
+        return None, None
 
-            if game.end_state:
-                logger.info(f'Game over: {game.end_state}')
-                emit('end_game', game.end_state)
-            if len(game.card_deck.active_cards) > 0:
-                game.card_deck.emit_active_cards()
-
-            if game.active_hack > 0:
-                emit('hack', game.active_hack)
-                logger.debug(f'Active hack: {game.active_hack}')
-            if game.meeting:
-                emit('meeting', game.meeting.to_json())
-                if game.meeting.stage == 'voting':
-                    game.meeting.emit_vote_counts()
-                logger.debug('Meeting is active')
-
-    @socketio.on('rejoin')
-    def handle_join_rejoin(data):
-        player = game.getPlayerById(data.get('player_id'))
+    def get_game_by_sid(sid):
+        player = sid_map.get(sid)
         if player:
-            logger.info('Existing player rejoining...')
+            return get_game_by_player(player)
+        return None, None
+
+    def send_player_list(game, room, action="player_list"):
+        logger.info("Sending player list to room %s", room)
+        player_list = [player.to_json() for player in game.players]
+        socketio.emit("game_data", {"action": action, "list": player_list}, room=room, json=True)
+
+    @socketio.on("connect")
+    def handle_connect():
+        logger.info("Client connected: %s", request.sid)
+        emit("task_locations", locations, json=True)
+
+    @socketio.on("create_room")
+    def handle_create_room():
+        code = generate_room_code()
+        while code in rooms:
+            code = generate_room_code()
+
+        task_handler = TaskHandler(locations)
+        game = Game(
+            socketio,
+            task_handler,
+            speaker,
+            config["task_ratio"],
+            config["meltdown_time"],
+            config["code_percent"],
+            locations,
+            config["vote_time"],
+            config["card_draw_probability"],
+            config["number_of_imposters"],
+            config["starting_cards"],
+            room=code,
+        )
+        rooms[code] = {"game": game, "task_handler": task_handler}
+        emit("room_created", {"room": code})
+
+    @socketio.on("rejoin")
+    def handle_rejoin(data):
+        player_id = data.get("player_id")
+        room = data.get("room") or player_rooms.get(player_id)
+        if not room or room not in rooms:
+            return
+
+        game = rooms[room]["game"]
+        join_room(room)
+        sid_map[request.sid] = player_id
+        player = game.getPlayerById(player_id)
+        if player:
             player.sid = request.sid
-            send_player_list('rejoin')
+            send_player_list(game, room, "rejoin")
 
             if game.denied_location:
-                emit('active_denial', game.denied_location)
+                emit("active_denial", game.denied_location, room=room)
 
             if player.meltdown_code and game.active_meltdown:
-                emit('meltdown_code', player.meltdown_code, to=player.sid)
-                logger.debug(f'Sent meltdown code to player {player.player_id}')
+                emit("meltdown_code", player.meltdown_code, to=player.sid)
 
             if player.get_task():
-                logger.info('Sending task to player')
-                emit('task', {'task': player.get_task()}, to=player.sid)
+                emit("task", {"task": player.get_task()}, to=player.sid)
 
-    @socketio.on('add_task')
+            if game.game_running:
+                emit("game_start", room=player.sid)
+                emit("crew_score", {"score": game.crew_score}, to=player.sid)
+                emit("task_goal", game.taskGoal, to=player.sid)
+                if game.end_state:
+                    emit("end_game", game.end_state, to=player.sid)
+                if len(game.card_deck.active_cards) > 0:
+                    game.card_deck.emit_active_cards()
+                if game.active_hack > 0:
+                    emit("hack", game.active_hack, to=player.sid)
+                if game.meeting:
+                    emit("meeting", game.meeting.to_json(), to=player.sid)
+                    if game.meeting.stage == "voting":
+                        game.meeting.emit_vote_counts()
+
+    @socketio.on("add_task")
     def add_task(data):
-        task_handler.add_task(data)
+        game, room = get_game_by_sid(request.sid)
+        if not game:
+            return
+        rooms[room]["task_handler"].add_task(data)
 
-    @socketio.on('complete_task')
+    @socketio.on("complete_task")
     def handle_task_complete(data):
-        player = game.getPlayerById(data.get('player_id'))
+        game, room = get_game_by_player(data.get("player_id"))
+        if not game:
+            return
+        task_handler = rooms[room]["task_handler"]
+        player = game.getPlayerById(data.get("player_id"))
         if player and len(task_handler.tasks) > 0:
             game.crew_score += 1
-            emit('crew_score', {'score': game.crew_score}, broadcast=True)
-            logger.info(f'Player {player.player_id} completed a task. Crew score: {game.crew_score}')
+            emit("crew_score", {"score": game.crew_score}, room=room)
             player.task = game.getTask()
-            emit('task', {'task': player.task}, to=player.sid)
-            logger.debug(f'Assigned new task to player {player.player_id}: {player.task}')
+            emit("task", {"task": player.task}, to=player.sid)
         elif player and len(task_handler.tasks) == 0:
             player.task = None
-            emit('task', {'task': 'No More Tasks'}, to=player.sid)
-            logger.info(f'No more tasks available. Informed player {player.player_id}')
+            emit("task", {"task": "No More Tasks"}, to=player.sid)
 
-    def handle_hack(hack_length=30):
-        if not game.active_hack and not game.meeting:
-            logger.info('Hack initiated.')
-            game.start_hack(hack_length)
-            speaker.play_sound('hack')
-            logger.debug('Hack started with a duration of 30 seconds')
-
-    @socketio.on('play_card')
+    @socketio.on("play_card")
     def play_card(data):
-        player = game.getPlayerById(data.get('player_id'))
-        card = player.get_card(data.get('card_id'))
+        game, _ = get_game_by_player(data.get("player_id"))
+        if not game:
+            return
+        player = game.getPlayerById(data.get("player_id"))
+        card = player.get_card(data.get("card_id")) if player else None
         if card:
             card.play_card(player)
 
-    @socketio.on('meeting')
+    @socketio.on("meeting")
     def handle_meeting(data):
-        if not game.meeting:
-            speaker.play_sound('meeting')
-            player = game.getPlayerById(data.get('player_id'))
+        game, room = get_game_by_player(data.get("player_id"))
+        if game and not game.meeting:
+            speaker.play_sound("meeting")
+            player = game.getPlayerById(data.get("player_id"))
             game.start_meeting(player)
-            logger.info('Meeting started')
+            logger.info("Meeting started")
 
-    @socketio.on('ready')
+    @socketio.on("ready")
     def handle_ready(data):
-        player = game.getPlayerById(data.get('player_id'))
-        player.ready = True
-        send_player_list()
-        game.try_start_voting()  # only starts if all players are ready
+        game, room = get_game_by_player(data.get("player_id"))
+        if not game:
+            return
+        player = game.getPlayerById(data.get("player_id"))
+        if player:
+            player.ready = True
+            send_player_list(game, room)
+            game.try_start_voting()
 
-    @socketio.on('vote')
+    @socketio.on("vote")
     def handle_vote(data):
-        voting_player = game.getPlayerById(data.get('player_id'))
-        voted_for = game.getPlayerById(data.get('votedFor'))
-        game.meeting.register_vote(voting_player, voted_for)
+        game, _ = get_game_by_player(data.get("player_id"))
+        if not game:
+            return
+        voting_player = game.getPlayerById(data.get("player_id"))
+        voted_for = game.getPlayerById(data.get("votedFor"))
+        if voting_player:
+            game.meeting.register_vote(voting_player, voted_for)
 
-    @socketio.on('veto')
+    @socketio.on("veto")
     def handle_veto(data):
-        voting_player = game.getPlayerById(data.get('player_id'))
-        game.meeting.register_vote(voting_player, veto=True)
+        game, _ = get_game_by_player(data.get("player_id"))
+        if not game:
+            return
+        voting_player = game.getPlayerById(data.get("player_id"))
+        if voting_player:
+            game.meeting.register_vote(voting_player, veto=True)
 
-    @socketio.on('end_meeting')
+    @socketio.on("end_meeting")
     def handle_end_meeting():
-        if game.meeting:
-            emit('end_meeting', broadcast=True)
+        game, room = get_game_by_sid(request.sid)
+        if game and game.meeting:
+            emit("end_meeting", room=room)
             game.meeting = False
-            logger.info('Meeting ended')
 
-    @socketio.on('meltdown')
+    @socketio.on("meltdown")
     def handle_meltdown():
-        game.start_meltdown()
-        logger.warning('Meltdown occurred.')
+        game, _ = get_game_by_sid(request.sid)
+        if game:
+            game.start_meltdown()
 
-    @socketio.on('pin_entry')
+    @socketio.on("pin_entry")
     def handle_pin_entry(data):
-        logger.info('Pin entered')
-        game.check_pin(data)
-        logger.debug(f'Pin data: {data}')
+        game, _ = get_game_by_sid(request.sid)
+        if game:
+            game.check_pin(data)
 
-    @socketio.on('player_dead')
+    @socketio.on("player_dead")
     def handle_death(data):
-        game.kill_player(data.get('player_id'))
+        game, _ = get_game_by_player(data.get("player_id"))
+        if game:
+            game.kill_player(data.get("player_id"))
 
-    @socketio.on('reset')
+    @socketio.on("reset")
     def reset_game():
+        game, room = get_game_by_sid(request.sid)
+        if not game:
+            return
         for player in game.players:
             player.reset()
-        send_player_list()
-        logger.info('Game has been reset')
+        send_player_list(game, room)
 
-    @socketio.on('start_game')
+    @socketio.on("start_game")
     def handle_start(data):
-        if game.game_running:
-            logger.warning('Start game attempted but game is already running')
+        game, room = get_game_by_player(data.get("player_id"))
+        if not game:
             return
-
-        speaker.play_sound('theme')
+        task_handler = rooms[room]["task_handler"]
+        if game.game_running:
+            return
+        speaker.play_sound("theme")
         game.game_running = True
         game.assignRoles()
-        send_player_list('start_game')
-        emit('task_goal', game.taskGoal, broadcast=True)
-        logger.info('Game started')
-
+        send_player_list(game, room, "start_game")
+        emit("task_goal", game.taskGoal, room=room)
         for player in game.players:
             if not player.sus and len(task_handler.tasks) > 0:
                 player.task = game.getTask()
-                emit('task', {'task': player.task}, to=player.sid)
-                logger.debug(f'Assigned task to player {player.player_id}: {player.task}')
+                emit("task", {"task": player.task}, to=player.sid)
 
-    @socketio.on('join')
+    @socketio.on("join")
     def handle_join(data):
-        player_id = data.get('player_id')
-        username = data.get('username')
+        room = data.get("room")
+        username = data.get("username")
+        player_id = data.get("player_id")
         sid = request.sid
 
+        if not room or room not in rooms:
+            emit("error", {"message": "Invalid room"}, to=sid)
+            return
+        game = rooms[room]["game"]
+        join_room(room)
+
         if not username:
-            emit('error', {'message': 'Username is required'}, to=sid)
-            logger.warning(f'Join attempt without username from SID: {sid}')
+            emit("error", {"message": "Username is required"}, to=sid)
             return
 
         if player_id:
@@ -179,25 +251,23 @@ def register_socket_handlers(socketio: SocketIO, game, task_handler, speaker, lo
             if player:
                 player.sid = sid
                 player.username = username
-                logger.info(f'Player {player.username} (ID: {player.player_id}) reconnected with new SID: {sid}')
             else:
                 if game.game_running:
-                    logger.warning(f'Join attempt with invalid player_id: {player_id} while game is running')
                     return
                 player = game.addPlayer(sid, username)
-                emit('player_id', {'player_id': player.player_id}, to=sid)
-                logger.info(f'New player {username} joined with new ID {player.player_id}')
+                emit("player_id", {"player_id": player.player_id, "room": room}, to=sid)
         else:
             if game.game_running:
-                logger.warning(f'Join attempt without player_id while game is running for username: {username}')
                 return
             player = game.addPlayer(sid, username)
-            emit('player_id', {'player_id': player.player_id, 'pic': player.pic}, to=sid)
-            logger.info(f'New player {username} joined with ID {player.player_id}')
+            emit("player_id", {"player_id": player.player_id, "room": room, "pic": player.pic}, to=sid)
 
-        send_player_list()
+        player_rooms[player.player_id] = room
+        sid_map[sid] = player.player_id
+        send_player_list(game, room)
 
-    @socketio.on('disconnect')
+    @socketio.on("disconnect")
     def handle_disconnect():
-        logger.info(f'Client disconnected: {request.sid}')
+        logger.info("Client disconnected: %s", request.sid)
+        sid_map.pop(request.sid, None)
 

--- a/server/socket_handlers.py
+++ b/server/socket_handlers.py
@@ -35,12 +35,12 @@ def register_socket_handlers(socketio: SocketIO, speaker, config, logger):
     def send_player_list(game, room, action="player_list"):
         logger.info("Sending player list to room %s", room)
         player_list = [player.to_json() for player in game.players]
-        socketio.emit("game_data", {"action": action, "list": player_list}, room=room, json=True)
+        socketio.emit("game_data", {"action": action, "list": player_list}, room=room)
 
     @socketio.on("connect")
     def handle_connect():
         logger.info("Client connected: %s", request.sid)
-        emit("task_locations", locations, json=True)
+        emit("task_locations", locations)
 
     @socketio.on("create_room")
     def handle_create_room():

--- a/server/socket_handlers.py
+++ b/server/socket_handlers.py
@@ -1,0 +1,203 @@
+# Socket event handlers for the game
+
+from flask import request
+from flask_socketio import emit, SocketIO
+
+
+def register_socket_handlers(socketio: SocketIO, game, task_handler, speaker, locations, logger):
+    """Register all socket.io event handlers."""
+
+    def send_player_list(action='player_list'):
+        logger.info("Sending player list to all clients")
+        player_list = [player.to_json() for player in game.players]
+        emit('game_data', {'action': action, 'list': player_list}, broadcast=True, json=True)
+
+    @socketio.on('connect')
+    def handle_connect():
+        logger.info(f'Client connected: {request.sid}')
+        emit('task_locations', locations, json=True)
+
+        if game.game_running:
+            emit('game_start')
+            emit('crew_score', {'score': game.crew_score})
+            emit('task_goal', game.taskGoal)
+
+            if game.end_state:
+                logger.info(f'Game over: {game.end_state}')
+                emit('end_game', game.end_state)
+            if len(game.card_deck.active_cards) > 0:
+                game.card_deck.emit_active_cards()
+
+            if game.active_hack > 0:
+                emit('hack', game.active_hack)
+                logger.debug(f'Active hack: {game.active_hack}')
+            if game.meeting:
+                emit('meeting', game.meeting.to_json())
+                if game.meeting.stage == 'voting':
+                    game.meeting.emit_vote_counts()
+                logger.debug('Meeting is active')
+
+    @socketio.on('rejoin')
+    def handle_join_rejoin(data):
+        player = game.getPlayerById(data.get('player_id'))
+        if player:
+            logger.info('Existing player rejoining...')
+            player.sid = request.sid
+            send_player_list('rejoin')
+
+            if game.denied_location:
+                emit('active_denial', game.denied_location)
+
+            if player.meltdown_code and game.active_meltdown:
+                emit('meltdown_code', player.meltdown_code, to=player.sid)
+                logger.debug(f'Sent meltdown code to player {player.player_id}')
+
+            if player.get_task():
+                logger.info('Sending task to player')
+                emit('task', {'task': player.get_task()}, to=player.sid)
+
+    @socketio.on('add_task')
+    def add_task(data):
+        task_handler.add_task(data)
+
+    @socketio.on('complete_task')
+    def handle_task_complete(data):
+        player = game.getPlayerById(data.get('player_id'))
+        if player and len(task_handler.tasks) > 0:
+            game.crew_score += 1
+            emit('crew_score', {'score': game.crew_score}, broadcast=True)
+            logger.info(f'Player {player.player_id} completed a task. Crew score: {game.crew_score}')
+            player.task = game.getTask()
+            emit('task', {'task': player.task}, to=player.sid)
+            logger.debug(f'Assigned new task to player {player.player_id}: {player.task}')
+        elif player and len(task_handler.tasks) == 0:
+            player.task = None
+            emit('task', {'task': 'No More Tasks'}, to=player.sid)
+            logger.info(f'No more tasks available. Informed player {player.player_id}')
+
+    def handle_hack(hack_length=30):
+        if not game.active_hack and not game.meeting:
+            logger.info('Hack initiated.')
+            game.start_hack(hack_length)
+            speaker.play_sound('hack')
+            logger.debug('Hack started with a duration of 30 seconds')
+
+    @socketio.on('play_card')
+    def play_card(data):
+        player = game.getPlayerById(data.get('player_id'))
+        card = player.get_card(data.get('card_id'))
+        if card:
+            card.play_card(player)
+
+    @socketio.on('meeting')
+    def handle_meeting(data):
+        if not game.meeting:
+            speaker.play_sound('meeting')
+            player = game.getPlayerById(data.get('player_id'))
+            game.start_meeting(player)
+            logger.info('Meeting started')
+
+    @socketio.on('ready')
+    def handle_ready(data):
+        player = game.getPlayerById(data.get('player_id'))
+        player.ready = True
+        send_player_list()
+        game.try_start_voting()  # only starts if all players are ready
+
+    @socketio.on('vote')
+    def handle_vote(data):
+        voting_player = game.getPlayerById(data.get('player_id'))
+        voted_for = game.getPlayerById(data.get('votedFor'))
+        game.meeting.register_vote(voting_player, voted_for)
+
+    @socketio.on('veto')
+    def handle_veto(data):
+        voting_player = game.getPlayerById(data.get('player_id'))
+        game.meeting.register_vote(voting_player, veto=True)
+
+    @socketio.on('end_meeting')
+    def handle_end_meeting():
+        if game.meeting:
+            emit('end_meeting', broadcast=True)
+            game.meeting = False
+            logger.info('Meeting ended')
+
+    @socketio.on('meltdown')
+    def handle_meltdown():
+        game.start_meltdown()
+        logger.warning('Meltdown occurred.')
+
+    @socketio.on('pin_entry')
+    def handle_pin_entry(data):
+        logger.info('Pin entered')
+        game.check_pin(data)
+        logger.debug(f'Pin data: {data}')
+
+    @socketio.on('player_dead')
+    def handle_death(data):
+        game.kill_player(data.get('player_id'))
+
+    @socketio.on('reset')
+    def reset_game():
+        for player in game.players:
+            player.reset()
+        send_player_list()
+        logger.info('Game has been reset')
+
+    @socketio.on('start_game')
+    def handle_start(data):
+        if game.game_running:
+            logger.warning('Start game attempted but game is already running')
+            return
+
+        speaker.play_sound('theme')
+        game.game_running = True
+        game.assignRoles()
+        send_player_list('start_game')
+        emit('task_goal', game.taskGoal, broadcast=True)
+        logger.info('Game started')
+
+        for player in game.players:
+            if not player.sus and len(task_handler.tasks) > 0:
+                player.task = game.getTask()
+                emit('task', {'task': player.task}, to=player.sid)
+                logger.debug(f'Assigned task to player {player.player_id}: {player.task}')
+
+    @socketio.on('join')
+    def handle_join(data):
+        player_id = data.get('player_id')
+        username = data.get('username')
+        sid = request.sid
+
+        if not username:
+            emit('error', {'message': 'Username is required'}, to=sid)
+            logger.warning(f'Join attempt without username from SID: {sid}')
+            return
+
+        if player_id:
+            player = game.getPlayerById(player_id)
+            if player:
+                player.sid = sid
+                player.username = username
+                logger.info(f'Player {player.username} (ID: {player.player_id}) reconnected with new SID: {sid}')
+            else:
+                if game.game_running:
+                    logger.warning(f'Join attempt with invalid player_id: {player_id} while game is running')
+                    return
+                player = game.addPlayer(sid, username)
+                emit('player_id', {'player_id': player.player_id}, to=sid)
+                logger.info(f'New player {username} joined with new ID {player.player_id}')
+        else:
+            if game.game_running:
+                logger.warning(f'Join attempt without player_id while game is running for username: {username}')
+                return
+            player = game.addPlayer(sid, username)
+            emit('player_id', {'player_id': player.player_id, 'pic': player.pic}, to=sid)
+            logger.info(f'New player {username} joined with ID {player.player_id}')
+
+        send_player_list()
+
+    @socketio.on('disconnect')
+    def handle_disconnect():
+        logger.info(f'Client disconnected: {request.sid}')
+


### PR DESCRIPTION
## Summary
- factor all socket events out of app.py
- create dedicated `socket_handlers.py` for event logic
- standardize socketio parameter names and remove ad‑hoc `emit` usage
- rename veto handler to avoid function name clash
- keep index route while trimming down `app.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ed48d54a4832db610bfa2113b27f8