### PR TITLE
Add multi-room support

### DIFF
--- a/client/src/ENDPOINT.js
+++ b/client/src/ENDPOINT.js
@@ -1,1 +1,1 @@
-export const ENDPOINT = '192.168.1.109:5000'
+export const ENDPOINT = "http://192.168.2.42:5000";

--- a/client/src/GameContext.js
+++ b/client/src/GameContext.js
@@ -37,6 +37,7 @@ export default function GameContext({ children }) {
     const [codesNeeded, setCodesNeeded] = useState(undefined);
     const [endState, setEndState] = useState(undefined);
     const [taskEntry , setTaskEntry] = useState(false);
+    const [createRoom, setCreateRoom] = useState(false);
     const [taskLocations, setTaskLocations] = useState([]);
 
     useEffect(() => {
@@ -57,6 +58,10 @@ export default function GameContext({ children }) {
     const resetState = () => {
         setGameState({})
         setConnected(false)
+        clearGameState()
+    }
+
+    const clearGameState = () => {
         setPlayers([])
         setPlayerState({
             username: '',
@@ -80,6 +85,7 @@ export default function GameContext({ children }) {
         setShowSusPage(false)
         setActiveCards([])
         setModalOpen(false)
+        setCreateRoom(false)
     }
 
     const leaveRoom = () => {
@@ -91,7 +97,7 @@ export default function GameContext({ children }) {
         }
         setRoomId('');
         localStorage.removeItem('room_id');
-        resetState();
+        clearGameState();
     }
 
     const resetMessage = (delay) => {
@@ -343,6 +349,9 @@ export default function GameContext({ children }) {
                     console.error("Unexpected data format:", data);
                 }
 
+                if (data.running) {
+                    setRunning(true);
+                }
                 if (data.action === "start_game" && me) {
                     setAudio('start');
                     setRunning(true);
@@ -406,6 +415,8 @@ export default function GameContext({ children }) {
         setCodesNeeded,
         taskEntry,
         setTaskEntry,
+        createRoom,
+        setCreateRoom,
         taskLocations,
         deniedLocation,
         votes,
@@ -450,7 +461,9 @@ export default function GameContext({ children }) {
         killCooldown,
         activeCards,
         modalOpen,
-        leaveRoom
+        leaveRoom,
+        createRoom,
+        setCreateRoom
     ]);
 
     return (

--- a/client/src/GameContext.js
+++ b/client/src/GameContext.js
@@ -82,6 +82,18 @@ export default function GameContext({ children }) {
         setModalOpen(false)
     }
 
+    const leaveRoom = () => {
+        if (socketRef.current) {
+            socketRef.current.emit('leave_room', {
+                player_id: playerState.playerId,
+                room_id: roomId,
+            });
+        }
+        setRoomId('');
+        localStorage.removeItem('room_id');
+        resetState();
+    }
+
     const resetMessage = (delay) => {
         if (message !== undefined) {
             const timer = setTimeout(() => {
@@ -407,7 +419,8 @@ export default function GameContext({ children }) {
         setKillCooldown,
         activeCards,
         modalOpen,
-        setModalOpen
+        setModalOpen,
+        leaveRoom
     }), [
         endState,
         meltdownCode,
@@ -436,7 +449,8 @@ export default function GameContext({ children }) {
         showSusPage,
         killCooldown,
         activeCards,
-        modalOpen
+        modalOpen,
+        leaveRoom
     ]);
 
     return (

--- a/client/src/GameContext.js
+++ b/client/src/GameContext.js
@@ -14,6 +14,7 @@ export default function GameContext({ children }) {
         username: '',
         playerId: localStorage.getItem('player_id') || '',
     });
+    const [roomId, setRoomId] = useState(localStorage.getItem('room_id') || '');
 
     // united states
     const [gameState, setGameState] = useState({}); // <--- USE this PLEASE we need to refactor this shit
@@ -37,6 +38,12 @@ export default function GameContext({ children }) {
     const [endState, setEndState] = useState(undefined);
     const [taskEntry , setTaskEntry] = useState(false);
     const [taskLocations, setTaskLocations] = useState([]);
+
+    useEffect(() => {
+        if (roomId) {
+            localStorage.setItem('room_id', roomId);
+        }
+    }, [roomId]);
     const [deniedLocation, setDeniedLocation] = useState(undefined)
     const [votes, setVotes] = useState({})
     const [vetoVotes, setVetoVotes] = useState(0); 
@@ -143,6 +150,7 @@ export default function GameContext({ children }) {
             setConnected(true);
             socketRef.current.emit('rejoin', {
                 player_id: playerState.playerId,
+                room_id: roomId,
             });
         });
 
@@ -352,6 +360,8 @@ export default function GameContext({ children }) {
     const contextValue = useMemo(() => ({
         playerState,
         setPlayerState,
+        roomId,
+        setRoomId,
         gameState,
         setGameState,
         socket: socketRef.current,
@@ -406,6 +416,7 @@ export default function GameContext({ children }) {
         hackTime, 
         audio,
         playerState,
+        roomId,
         gameState,
         connected,
         players,

--- a/client/src/PageController.js
+++ b/client/src/PageController.js
@@ -155,6 +155,7 @@ const PageController = () => {
         endState,
         taskEntry,
         showSusPage,
+        createRoom,
 
     ]);
 

--- a/client/src/PageController.js
+++ b/client/src/PageController.js
@@ -5,6 +5,7 @@ import LoginPage from "./pages/Login";
 import ConnectingPage from "./pages/ConnectingPage";
 import PlayersPage from "./pages/PlayersPage";
 import Modal from "./components/Modal";
+import RoomBanner from "./components/RoomBanner";
 import ImposterPage from "./pages/ImposterPage";
 import CrewmemberPage from "./pages/CrewPage";
 import ProgressBar from "./components/ProgressBar";
@@ -23,6 +24,7 @@ import ReactorWaiting from "./pages/ReactorWaiting";
 import TaskEntryPage from "./pages/TaskEntryPage";
 import VotingPage from "./pages/VotingPage";
 import MeetingResultPage from "./pages/MeetingResultsPage";
+import CreateRoomPage from "./pages/CreateRoom";
 
 const PageController = () => {
     const {
@@ -40,6 +42,9 @@ const PageController = () => {
         taskEntry,
         showSusPage,
         setShowSusPage,
+        createRoom,
+        roomId,
+        leaveRoom,
     } = useContext(DataContext);
 
     const [currentPage, setCurrentPage] = useState("connecting");
@@ -76,6 +81,11 @@ const PageController = () => {
         if (taskEntry) {
             console.log("task entry")
             setCurrentPage("taskEntry")
+            return;
+        }
+
+        if (createRoom) {
+            setCurrentPage("createRoom");
             return;
         }
 
@@ -168,6 +178,7 @@ const PageController = () => {
         meltdown_fail: <NuclearMeltdownScreen />,
         reactorWaiting: <ReactorWaiting />,
         taskEntry: <TaskEntryPage />,
+        createRoom: <CreateRoomPage />,
         unknown: (
             <p>
                 You're really not supposed to see this... Uhhh please go talk to
@@ -179,6 +190,7 @@ const PageController = () => {
     return (
         <div>
             <Modal />
+            <RoomBanner roomId={roomId} onLeave={leaveRoom} />
             {running && isMobile && !endState && (
                 <ProgressBar
                     score={crewScore}

--- a/client/src/components/ProgressBar.js
+++ b/client/src/components/ProgressBar.js
@@ -18,7 +18,7 @@ const ProgressBar = ({ score, goalScore, sus }) => {
   const message = sus ? 'Eliminate Crew' : 'Complete Tasks';
 
   return (
-    <div className="fixed top-0 w-full z-50 bg-gray-900">
+    <div className="fixed top-8 w-full z-50 bg-gray-900">
       <div className="max-w-md mx-auto px-2 py-1 flex items-center space-x-2 text-xs text-gray-300">
         {/* Message */}
         <span className="whitespace-nowrap">{message}</span>

--- a/client/src/components/RoomBanner.js
+++ b/client/src/components/RoomBanner.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const RoomBanner = ({ roomId, onLeave }) => {
+  if (!roomId) return null;
+  return (
+    <div className="fixed top-0 left-0 w-full z-50 bg-gray-900 text-gray-200 text-xs flex justify-end items-center p-2 space-x-4">
+      <span>Room: {roomId}</span>
+      <button onClick={onLeave} className="text-red-400 hover:text-red-500">Leave</button>
+    </div>
+  );
+};
+
+export default RoomBanner;

--- a/client/src/pages/CreateRoom.js
+++ b/client/src/pages/CreateRoom.js
@@ -1,0 +1,72 @@
+import React, { useState, useContext, useEffect } from 'react';
+import { ChevronLeft } from 'lucide-react';
+import { DataContext } from '../GameContext';
+
+function CreateRoomPage() {
+    const [username, setUsername] = useState('');
+    const [errorMsg, setErrorMsg] = useState('');
+    const { socket, setPlayerState, setRoomId, setCreateRoom } = useContext(DataContext);
+
+    useEffect(() => {
+        socket.on('room_created', (data) => {
+            setRoomId(data.room_id);
+            const playerId = localStorage.getItem('player_id');
+            setPlayerState(prev => ({ ...prev, username }));
+            socket.emit('join', { player_id: playerId, username, room_id: data.room_id });
+            setCreateRoom(false);
+        });
+        socket.on('error', (data) => setErrorMsg(data.message));
+        return () => {
+            socket.off('room_created');
+            socket.off('error');
+        };
+    }, [socket, username, setRoomId, setPlayerState, setCreateRoom]);
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (!username) {
+            setErrorMsg('Username required');
+            return;
+        }
+        socket.emit('create_room');
+    };
+
+    return (
+        <div className="flex items-center justify-center min-h-screen bg-gradient-to-tr from-gray-800 to-gray-900 p-6 relative">
+            <button
+                type="button"
+                onClick={() => setCreateRoom(false)}
+                className="absolute top-6 left-6 flex items-center text-gray-300 hover:text-white transition-colors"
+            >
+                <ChevronLeft className="mr-1" />
+                <span className="text-sm">Back</span>
+            </button>
+            <div className="relative bg-gray-700 bg-opacity-90 backdrop-blur-md p-8 rounded-lg shadow-lg max-w-sm w-full">
+                <h2 className="text-2xl font-bold mb-4 text-gray-100 text-center">Create Room</h2>
+                <form onSubmit={handleSubmit}>
+                    <div className="mb-4">
+                        <label htmlFor="username" className="block text-gray-300 mb-2">Username</label>
+                        <input
+                            type="text"
+                            id="username"
+                            value={username}
+                            onChange={(e) => setUsername(e.target.value)}
+                            className="w-full px-4 py-2 border border-gray-500 rounded-lg bg-gray-600 text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                            placeholder="Enter your username"
+                            required
+                        />
+                    </div>
+                    {errorMsg && <div className="mb-2 text-red-400 text-sm">{errorMsg}</div>}
+                    <button
+                        type="submit"
+                        className="w-full bg-green-600 text-white py-2 px-4 rounded-lg hover:bg-green-700 transition-colors focus:outline-none focus:ring-2 focus:ring-green-400"
+                    >
+                        Create Room
+                    </button>
+                </form>
+            </div>
+        </div>
+    );
+}
+
+export default CreateRoomPage;

--- a/client/src/pages/CreateRoom.js
+++ b/client/src/pages/CreateRoom.js
@@ -8,19 +8,11 @@ function CreateRoomPage() {
     const { socket, setPlayerState, setRoomId, setCreateRoom } = useContext(DataContext);
 
     useEffect(() => {
-        socket.on('room_created', (data) => {
-            setRoomId(data.room_id);
-            const playerId = localStorage.getItem('player_id');
-            setPlayerState(prev => ({ ...prev, username }));
-            socket.emit('join', { player_id: playerId, username, room_id: data.room_id });
-            setCreateRoom(false);
-        });
         socket.on('error', (data) => setErrorMsg(data.message));
         return () => {
-            socket.off('room_created');
             socket.off('error');
         };
-    }, [socket, username, setRoomId, setPlayerState, setCreateRoom]);
+    }, [socket]);
 
     const handleSubmit = (e) => {
         e.preventDefault();
@@ -28,7 +20,16 @@ function CreateRoomPage() {
             setErrorMsg('Username required');
             return;
         }
-        socket.emit('create_room');
+        fetch('/api/rooms', { method: 'POST' })
+            .then(res => res.json())
+            .then(data => {
+                setRoomId(data.room_id);
+                const playerId = localStorage.getItem('player_id');
+                setPlayerState(prev => ({ ...prev, username }));
+                socket.emit('join', { player_id: playerId, username, room_id: data.room_id });
+                setCreateRoom(false);
+            })
+            .catch(() => setErrorMsg('Failed to create room'));
     };
 
     return (

--- a/client/src/pages/CreateRoom.js
+++ b/client/src/pages/CreateRoom.js
@@ -1,6 +1,7 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { ChevronLeft } from 'lucide-react';
 import { DataContext } from '../GameContext';
+import { ENDPOINT } from '../ENDPOINT';
 
 function CreateRoomPage() {
     const [username, setUsername] = useState('');
@@ -20,7 +21,7 @@ function CreateRoomPage() {
             setErrorMsg('Username required');
             return;
         }
-        fetch('/api/rooms', { method: 'POST' })
+        fetch(`${ENDPOINT}/api/rooms`, { method: 'POST' })
             .then(res => res.json())
             .then(data => {
                 setRoomId(data.room_id);

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -4,11 +4,13 @@ import { DataContext } from '../GameContext';
 
 function LoginPage() {
     const [username, setUsername] = useState('');
-    const { setPlayerState, socket, setTaskEntry } = useContext(DataContext);
+    const [roomCode, setRoomCode] = useState('');
+    const { setPlayerState, socket, setTaskEntry, roomId, setRoomId } = useContext(DataContext);
 
     useEffect(() => {
         window.scrollTo(0, 0);
-      }, []);
+        if (roomId) setRoomCode(roomId);
+      }, [roomId]);
     
 
     const handleJoin = async (e) => {
@@ -16,8 +18,21 @@ function LoginPage() {
 
         setPlayerState(prevState => ({ ...prevState, username: username }));
         let playerId = localStorage.getItem('player_id');
+        const room = roomCode || roomId;
+        if (!room) return;
+        setRoomId(room);
+        socket.emit('join', { player_id: playerId, username: username, room_id: room });
+    };
 
-        socket.emit('join', { player_id: playerId, username: username });
+    useEffect(() => {
+        socket.on('room_created', (data) => {
+            setRoomId(data.room_id);
+            setRoomCode(data.room_id);
+        });
+    }, [socket]);
+
+    const handleCreateRoom = () => {
+        socket.emit('create_room');
     };
 
     const handleEnterTasks = () => {
@@ -59,11 +74,31 @@ function LoginPage() {
                             required
                         />
                     </div>
+                    <div className="mb-4">
+                        <label htmlFor="room" className="block text-gray-300 mb-2">
+                            Room Code
+                        </label>
+                        <input
+                            type="text"
+                            id="room"
+                            value={roomCode}
+                            onChange={(e) => setRoomCode(e.target.value)}
+                            className="w-full px-4 py-2 border border-gray-500 rounded-lg bg-gray-600 text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400 transition-colors"
+                            placeholder="Enter room code"
+                        />
+                    </div>
                     <button
                         type="submit"
                         className="w-full bg-indigo-600 text-white py-2 px-4 rounded-lg hover:bg-indigo-700 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-400 transform hover:scale-105"
                     >
                         Join
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleCreateRoom}
+                        className="w-full mt-2 bg-green-600 text-white py-2 px-4 rounded-lg hover:bg-green-700 transition-colors focus:outline-none focus:ring-2 focus:ring-green-400"
+                    >
+                        Create Room
                     </button>
                 </form>
                 {/* Optional Decorative Text */}

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -6,7 +6,7 @@ function LoginPage() {
     const [username, setUsername] = useState('');
     const [roomCode, setRoomCode] = useState('');
     const [errorMsg, setErrorMsg] = useState('');
-    const { setPlayerState, socket, setTaskEntry, roomId, setRoomId } = useContext(DataContext);
+    const { setPlayerState, socket, setTaskEntry, roomId, setRoomId, setCreateRoom } = useContext(DataContext);
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -26,11 +26,6 @@ function LoginPage() {
     };
 
     useEffect(() => {
-        socket.on('room_created', (data) => {
-            setRoomId(data.room_id);
-            setRoomCode(data.room_id);
-            setErrorMsg('');
-        });
         socket.on('error', (data) => {
             if (data.message === 'Room not found') {
                 setRoomId('');
@@ -40,13 +35,12 @@ function LoginPage() {
             setErrorMsg(data.message);
         });
         return () => {
-            socket.off('room_created');
             socket.off('error');
         };
     }, [socket, setRoomId]);
 
     const handleCreateRoom = () => {
-        socket.emit('create_room');
+        setCreateRoom(true);
     };
 
     const handleEnterTasks = () => {

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -5,6 +5,7 @@ import { DataContext } from '../GameContext';
 function LoginPage() {
     const [username, setUsername] = useState('');
     const [roomCode, setRoomCode] = useState('');
+    const [errorMsg, setErrorMsg] = useState('');
     const { setPlayerState, socket, setTaskEntry, roomId, setRoomId } = useContext(DataContext);
 
     useEffect(() => {
@@ -28,8 +29,21 @@ function LoginPage() {
         socket.on('room_created', (data) => {
             setRoomId(data.room_id);
             setRoomCode(data.room_id);
+            setErrorMsg('');
         });
-    }, [socket]);
+        socket.on('error', (data) => {
+            if (data.message === 'Room not found') {
+                setRoomId('');
+                localStorage.removeItem('room_id');
+                setRoomCode('');
+            }
+            setErrorMsg(data.message);
+        });
+        return () => {
+            socket.off('room_created');
+            socket.off('error');
+        };
+    }, [socket, setRoomId]);
 
     const handleCreateRoom = () => {
         socket.emit('create_room');
@@ -74,6 +88,9 @@ function LoginPage() {
                             required
                         />
                     </div>
+                    {errorMsg && (
+                        <div className="mb-2 text-red-400 text-sm">{errorMsg}</div>
+                    )}
                     <div className="mb-4">
                         <label htmlFor="room" className="block text-gray-300 mb-2">
                             Room Code

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -17,12 +17,22 @@ function LoginPage() {
     const handleJoin = async (e) => {
         e.preventDefault();
 
-        setPlayerState(prevState => ({ ...prevState, username: username }));
-        let playerId = localStorage.getItem('player_id');
+        setPlayerState(prevState => ({ ...prevState, username }));
+        const playerId = localStorage.getItem('player_id');
         const room = roomCode || roomId;
         if (!room) return;
-        setRoomId(room);
-        socket.emit('join', { player_id: playerId, username: username, room_id: room });
+
+        try {
+            const res = await fetch(`/api/rooms/${room}`);
+            if (!res.ok) {
+                setErrorMsg('Room not found');
+                return;
+            }
+            setRoomId(room);
+            socket.emit('join', { player_id: playerId, username, room_id: room });
+        } catch {
+            setErrorMsg('Failed to reach server');
+        }
     };
 
     useEffect(() => {

--- a/client/src/pages/Login.js
+++ b/client/src/pages/Login.js
@@ -1,10 +1,11 @@
 import React, { useState, useContext, useEffect } from 'react';
 import { ChevronLeft } from 'lucide-react';
 import { DataContext } from '../GameContext';
+import { ENDPOINT } from '../ENDPOINT';
 
 function LoginPage() {
     const [username, setUsername] = useState('');
-    const [roomCode, setRoomCode] = useState('');
+    const [roomCode, setRoomCode] = useState(undefined);
     const [errorMsg, setErrorMsg] = useState('');
     const { setPlayerState, socket, setTaskEntry, roomId, setRoomId, setCreateRoom } = useContext(DataContext);
 
@@ -16,23 +17,25 @@ function LoginPage() {
 
     const handleJoin = async (e) => {
         e.preventDefault();
-
-        setPlayerState(prevState => ({ ...prevState, username }));
+        console.log("im called")
+        
         const playerId = localStorage.getItem('player_id');
-        const room = roomCode || roomId;
-        if (!room) return;
-
+        let room = roomCode || roomId;
         try {
-            const res = await fetch(`/api/rooms/${room}`);
+            const res = await fetch(ENDPOINT+`/api/rooms/${room}`);
+            console.log(res)
             if (!res.ok) {
                 setErrorMsg('Room not found');
                 return;
             }
             setRoomId(room);
             socket.emit('join', { player_id: playerId, username, room_id: room });
-        } catch {
+        } catch(e) {
+            console.log("i failed...", e)
             setErrorMsg('Failed to reach server');
         }
+        if (!room) return;
+        setPlayerState(prevState => ({ ...prevState, username }));
     };
 
     useEffect(() => {

--- a/client/src/pages/PlayersPage.js
+++ b/client/src/pages/PlayersPage.js
@@ -7,7 +7,7 @@ import PlayerCard from "../components/PlayerCard";
 import { ChevronLeft } from 'lucide-react';
 
 export default function PlayersPage() {
-    const { players, socket, setMessage, setAudio, running, setTaskEntry, roomId } = useContext(DataContext);
+    const { players, socket, setMessage, setAudio, running, setTaskEntry, roomId, leaveRoom } = useContext(DataContext);
 
     useEffect(() => {
         window.scrollTo(0, 0)
@@ -17,7 +17,11 @@ export default function PlayersPage() {
 
     if (!players || players.length === 0) {
         return (
-            <div className="flex items-center justify-center min-h-screen bg-gradient-to-tr from-gray-800 to-gray-900 p-6">
+            <div className="flex items-center justify-center min-h-screen bg-gradient-to-tr from-gray-800 to-gray-900 p-6 relative">
+                <div className="absolute top-6 right-6 text-gray-200 text-sm flex items-center space-x-4">
+                    <span>Room: {roomId}</span>
+                    <button onClick={leaveRoom} className="text-red-400 hover:text-red-500">Leave</button>
+                </div>
                 <div className="text-center text-gray-400">
                     <p className="text-lg">No players available</p>
                 </div>
@@ -40,6 +44,10 @@ export default function PlayersPage() {
                 <ChevronLeft className="mr-1" />
                 <span className="text-sm">Task Entry</span>
             </button>}
+            <div className="absolute top-6 right-6 text-gray-200 text-sm flex items-center space-x-4">
+                <span>Room: {roomId}</span>
+                <button onClick={leaveRoom} className="text-red-400 hover:text-red-500">Leave</button>
+            </div>
             <div className="max-w-6xl mx-auto">
                 <div className="flex flex-col items-center mb-6">
                     <button

--- a/client/src/pages/PlayersPage.js
+++ b/client/src/pages/PlayersPage.js
@@ -7,7 +7,7 @@ import PlayerCard from "../components/PlayerCard";
 import { ChevronLeft } from 'lucide-react';
 
 export default function PlayersPage() {
-    const { players, socket, setMessage, setAudio, running, setTaskEntry } = useContext(DataContext);
+    const { players, socket, setMessage, setAudio, running, setTaskEntry, roomId } = useContext(DataContext);
 
     useEffect(() => {
         window.scrollTo(0, 0)
@@ -26,7 +26,7 @@ export default function PlayersPage() {
     }
 
     function startGame() {
-        socket.emit('start_game', {});
+        socket.emit('start_game', { room_id: roomId });
 
     }
 

--- a/client/src/pages/PlayersPage.js
+++ b/client/src/pages/PlayersPage.js
@@ -18,10 +18,6 @@ export default function PlayersPage() {
     if (!players || players.length === 0) {
         return (
             <div className="flex items-center justify-center min-h-screen bg-gradient-to-tr from-gray-800 to-gray-900 p-6 relative">
-                <div className="absolute top-6 right-6 text-gray-200 text-sm flex items-center space-x-4">
-                    <span>Room: {roomId}</span>
-                    <button onClick={leaveRoom} className="text-red-400 hover:text-red-500">Leave</button>
-                </div>
                 <div className="text-center text-gray-400">
                     <p className="text-lg">No players available</p>
                 </div>
@@ -44,10 +40,6 @@ export default function PlayersPage() {
                 <ChevronLeft className="mr-1" />
                 <span className="text-sm">Task Entry</span>
             </button>}
-            <div className="absolute top-6 right-6 text-gray-200 text-sm flex items-center space-x-4">
-                <span>Room: {roomId}</span>
-                <button onClick={leaveRoom} className="text-red-400 hover:text-red-500">Leave</button>
-            </div>
             <div className="max-w-6xl mx-auto">
                 <div className="flex flex-col items-center mb-6">
                     <button

--- a/client/src/pages/ReactorPage.js
+++ b/client/src/pages/ReactorPage.js
@@ -7,6 +7,7 @@ function ReactorNormal() {
         meeting,
         hackTime,
         endState,
+        playerState
      } = useContext(DataContext);
     const [isSabotaging, setIsSabotaging] = useState(false);
 
@@ -18,7 +19,7 @@ function ReactorNormal() {
     const handleSabotage = () => {
         setIsSabotaging(true);
         setTimeout(() => {
-            socket.emit("meltdown");
+            socket.emit("meltdown", { player_id: playerState.playerId });
             setIsSabotaging(false);
         }, 3000);
     };

--- a/server/app.py
+++ b/server/app.py
@@ -108,6 +108,23 @@ def handleJoin(data):
         player_room[player.player_id] = room_id
         sendPlayerList(game, room_id, "rejoin")
 
+        if game.game_running:
+            emit("game_start", to=player.sid)
+            emit("crew_score", {"score": game.crew_score}, to=player.sid)
+            emit("task_goal", game.taskGoal, to=player.sid)
+
+            if game.end_state:
+                emit("end_game", game.end_state, to=player.sid)
+            if len(game.card_deck.active_cards) > 0:
+                game.card_deck.emit_active_cards()
+
+            if game.active_hack > 0:
+                emit("hack", game.active_hack, to=player.sid)
+            if game.meeting:
+                emit("meeting", game.meeting.to_json(), to=player.sid)
+                if game.meeting.stage == 'voting':
+                    game.meeting.emit_vote_counts()
+
         if game.denied_location:
             emit('active_denial', game.denied_location, room=room_id)
 
@@ -119,10 +136,11 @@ def handleJoin(data):
             logger.info("Sending task to player")
             emit("task", {"task": player.get_task()}, to=player.sid)
 
-@socketio.on('add_task') # this should use an api and not a socket
+@socketio.on('add_task')  # this should use an api and not a socket
 def addTask(data):
     print(data)
-    taskHandler.add_task(data)
+    for game in rooms.values():
+        game.task_handler.add_task(data)
 
 @socketio.on("complete_task")
 def handleTaskComplete(data):
@@ -143,12 +161,6 @@ def handleTaskComplete(data):
         emit("task", {"task": "No More Tasks"}, to=player.sid)
         logger.info(f"No more tasks available. Informed player {player.player_id}")
 
-def handleHack(hack_length=30):
-    if not game.active_hack and not game.meeting:
-        logger.info(f"Hack initiated. ")
-        game.start_hack(hack_length)
-        speaker.play_sound('hack')
-        logger.debug("Hack started with a duration of 30 seconds")
 
 @socketio.on("play_card")
 def playCard(data):
@@ -172,9 +184,9 @@ def handleMeeting(data):
     player = game.getPlayerById(player_id)
     game.start_meeting(player)
 
-        # emit("meeting", broadcast=True)
-        # game.meeting = True
-        logger.info("Meeting started")
+    # emit("meeting", broadcast=True)
+    # game.meeting = True
+    logger.info("Meeting started")
 
 @socketio.on("ready")
 def handleReady(data):

--- a/server/app.py
+++ b/server/app.py
@@ -69,7 +69,7 @@ def sendPlayerList(game, room, action='player_list'):
     logger.info(f"Sending player list to room {room}")
     player_list = [player.to_json() for player in game.players]
     logger.debug(f"Player List: {player_list}")
-    emit('game_data', {'action': action, 'list': player_list}, room=room, json=True)
+    emit('game_data', {'action': action, 'list': player_list, 'running': game.game_running}, room=room, json=True)
 
 def get_game_by_player(player_id):
     room = player_room.get(player_id)
@@ -90,6 +90,7 @@ def handle_connect():
 def handle_create_room():
     room_id = str(uuid4())[:4]
     rooms[room_id] = create_game(room_id)
+    logger.info(f"Room {room_id} created")
     emit('room_created', {'room_id': room_id}, to=request.sid)
 
 @socketio.on('rejoin')
@@ -98,6 +99,7 @@ def handleJoin(data):
     player_id = data.get('player_id')
     game = rooms.get(room_id)
     if not game:
+        logger.warning(f"Rejoin failed: room {room_id} not found")
         emit('error', {'message': 'Room not found'}, to=request.sid)
         return
     player = game.getPlayerById(player_id)
@@ -304,6 +306,7 @@ def handle_join(data):
         emit('error', {'message': 'Room not found'}, to=sid)
         return
     join_room(room_id)
+    logger.info(f"Player attempting to join room {room_id}")
 
     if not username:
         emit('error', {'message': 'Username is required'}, to=sid)
@@ -333,6 +336,7 @@ def handle_join(data):
         logger.info(f"New player {username} joined with ID {player.player_id}")
 
     player_room[player.player_id] = room_id
+    logger.info(f"Player {player.username} joined room {room_id}")
     sendPlayerList(game, room_id)
 
 @socketio.on('leave_room')
@@ -344,9 +348,11 @@ def handle_leave(data):
         return
     player = game.getPlayerById(player_id)
     if player:
+        logger.info(f"Player {player.username} leaving room {room_id}")
         game.players.remove(player)
         player_room.pop(player_id, None)
         if len(game.players) == 0:
+            logger.info(f"Room {room_id} is empty and will be removed")
             del rooms[room_id]
     sendPlayerList(game, room_id)
 

--- a/server/app.py
+++ b/server/app.py
@@ -88,7 +88,7 @@ def handle_connect():
 
 @socketio.on('create_room')
 def handle_create_room():
-    room_id = str(uuid4())[:6]
+    room_id = str(uuid4())[:4]
     rooms[room_id] = create_game(room_id)
     emit('room_created', {'room_id': room_id}, to=request.sid)
 
@@ -333,6 +333,21 @@ def handle_join(data):
         logger.info(f"New player {username} joined with ID {player.player_id}")
 
     player_room[player.player_id] = room_id
+    sendPlayerList(game, room_id)
+
+@socketio.on('leave_room')
+def handle_leave(data):
+    room_id = data.get('room_id')
+    player_id = data.get('player_id')
+    game = rooms.get(room_id)
+    if not game:
+        return
+    player = game.getPlayerById(player_id)
+    if player:
+        game.players.remove(player)
+        player_room.pop(player_id, None)
+        if len(game.players) == 0:
+            del rooms[room_id]
     sendPlayerList(game, room_id)
 
 @socketio.on('disconnect')

--- a/server/app.py
+++ b/server/app.py
@@ -38,7 +38,7 @@ ignore_bedroom_speakers = True
 import eventlet
 eventlet.monkey_patch()
 from flask import Flask, request
-from flask_socketio import SocketIO, emit, join_room
+from flask_socketio import SocketIO, emit, join_room, leave_room
 from flask_cors import CORS
 from assets.game import Game
 from assets.sonosHandler import SonosController
@@ -76,6 +76,23 @@ def get_game_by_player(player_id):
     if room:
         return rooms.get(room), room
     return None, None
+
+@app.route('/api/rooms/<room_id>', methods=['GET'])
+def api_check_room(room_id):
+    """Return 200 if the room exists so the client can verify rooms via HTTP."""
+    if room_id in rooms:
+        logger.debug(f"API check: room {room_id} exists")
+        return {'exists': True}, 200
+    logger.warning(f"API check failed: room {room_id} not found")
+    return {'error': 'Room not found'}, 404
+
+@app.route('/api/rooms', methods=['POST'])
+def api_create_room():
+    """Create a new room and return the room id."""
+    room_id = str(uuid4())[:4]
+    rooms[room_id] = create_game(room_id)
+    logger.info(f"Room {room_id} created via HTTP API")
+    return {'room_id': room_id}, 201
 
 @app.route('/')
 def index():
@@ -351,6 +368,7 @@ def handle_leave(data):
         logger.info(f"Player {player.username} leaving room {room_id}")
         game.players.remove(player)
         player_room.pop(player_id, None)
+        leave_room(room_id, sid=player.sid)
         if len(game.players) == 0:
             logger.info(f"Room {room_id} is empty and will be removed")
             del rooms[room_id]

--- a/server/app.py
+++ b/server/app.py
@@ -38,12 +38,13 @@ ignore_bedroom_speakers = True
 import eventlet
 eventlet.monkey_patch()
 from flask import Flask, request
-from flask_socketio import SocketIO, emit
+from flask_socketio import SocketIO, emit, join_room
 from flask_cors import CORS
 from assets.game import Game
 from assets.sonosHandler import SonosController
 from assets.utils import *
 from assets.taskHandler import *
+from uuid import uuid4
 
 logger = setup_logging()
 
@@ -51,20 +52,30 @@ app = Flask(__name__)
 CORS(app, resources={r"/*": {"origins": '*'}})
 socketio = SocketIO(app, cors_allowed_origins="*")
 
+rooms = {}
+player_room = {}
+
+def create_game(room_id):
+    task_handler = TaskHandler(locations)
+    return Game(socketio, task_handler, speaker, task_ratio, meltdown_time, code_percent, locations, vote_time, card_draw_probability, number_of_imposters, starting_cards, room=room_id)
+
 locations.append("Other")
 # big boi objects
 speaker = SonosController(enabled=sonos_enabled, default_volume=speaker_volume, ignore_bedroom_speakers=ignore_bedroom_speakers)
 if sonos_enabled:
     speaker.play_sound("theme")
 
-taskHandler = TaskHandler(locations)
-game = Game(socketio, taskHandler, speaker, task_ratio, meltdown_time, code_percent, locations, vote_time, card_draw_probability, number_of_imposters, starting_cards)
-
-def sendPlayerList(action='player_list'):
-    logger.info("Sending player list to all clients")
+def sendPlayerList(game, room, action='player_list'):
+    logger.info(f"Sending player list to room {room}")
     player_list = [player.to_json() for player in game.players]
     logger.debug(f"Player List: {player_list}")
-    emit('game_data', {'action': action, 'list': player_list}, broadcast=True, json=True)
+    emit('game_data', {'action': action, 'list': player_list}, room=room, json=True)
+
+def get_game_by_player(player_id):
+    room = player_room.get(player_id)
+    if room:
+        return rooms.get(room), room
+    return None, None
 
 @app.route('/')
 def index():
@@ -75,37 +86,30 @@ def handle_connect():
     logger.info(f'Client connected: {request.sid}')
     emit('task_locations', locations, json=True)
 
-    if game.game_running:
-        emit("game_start")
-        emit("crew_score", {"score": game.crew_score})
-        emit("task_goal", game.taskGoal)
-
-        if game.end_state:
-            logger.info(f"Game over: {game.end_state}")
-            emit("end_game", game.end_state)
-        if len(game.card_deck.active_cards) > 0:
-            game.card_deck.emit_active_cards()
-
-        if game.active_hack > 0:
-            emit("hack", game.active_hack)
-            logger.debug(f"Active hack: {game.active_hack}")
-        if game.meeting:
-            print(game.meeting.time_left)
-            emit("meeting", game.meeting.to_json())
-            if game.meeting.stage == 'voting':
-                game.meeting.emit_vote_counts()
-            logger.debug("Meeting is active")
+@socketio.on('create_room')
+def handle_create_room():
+    room_id = str(uuid4())[:6]
+    rooms[room_id] = create_game(room_id)
+    emit('room_created', {'room_id': room_id}, to=request.sid)
 
 @socketio.on('rejoin')
 def handleJoin(data):
-    player = game.getPlayerById(data.get('player_id'))
+    room_id = data.get('room_id')
+    player_id = data.get('player_id')
+    game = rooms.get(room_id)
+    if not game:
+        emit('error', {'message': 'Room not found'}, to=request.sid)
+        return
+    player = game.getPlayerById(player_id)
     if player:
         logger.info("Existing player rejoining...")
         player.sid = request.sid
-        sendPlayerList("rejoin")
+        join_room(room_id)
+        player_room[player.player_id] = room_id
+        sendPlayerList(game, room_id, "rejoin")
 
         if game.denied_location:
-            emit('active_denial', game.denied_location)
+            emit('active_denial', game.denied_location, room=room_id)
 
         if player.meltdown_code and game.active_meltdown:
             emit("meltdown_code", player.meltdown_code, to=player.sid)
@@ -122,15 +126,19 @@ def addTask(data):
 
 @socketio.on("complete_task")
 def handleTaskComplete(data):
-    player = game.getPlayerById(data.get('player_id'))
-    if player and len(taskHandler.tasks) > 0:
+    player_id = data.get('player_id')
+    game, room = get_game_by_player(player_id)
+    if not game:
+        return
+    player = game.getPlayerById(player_id)
+    if player and len(game.task_handler.tasks) > 0:
         game.crew_score += 1
-        emit("crew_score", {"score": game.crew_score}, broadcast=True)
+        emit("crew_score", {"score": game.crew_score}, room=room)
         logger.info(f"Player {player.player_id} completed a task. Crew score: {game.crew_score}")
         player.task = game.getTask()
         emit("task", {"task": player.task}, to=player.sid)
         logger.debug(f"Assigned new task to player {player.player_id}: {player.task}")
-    elif player and len(taskHandler.tasks) == 0:
+    elif player and len(game.task_handler.tasks) == 0:
         player.task = None
         emit("task", {"task": "No More Tasks"}, to=player.sid)
         logger.info(f"No more tasks available. Informed player {player.player_id}")
@@ -145,17 +153,24 @@ def handleHack(hack_length=30):
 @socketio.on("play_card")
 def playCard(data):
     print(data)
-    player = game.getPlayerById(data.get('player_id'))
+    player_id = data.get('player_id')
+    game, _ = get_game_by_player(player_id)
+    if not game:
+        return
+    player = game.getPlayerById(player_id)
     card = player.get_card(data.get('card_id'))
     if card:
         card.play_card(player)
 
 @socketio.on("meeting")
 def handleMeeting(data):
-    if not game.meeting:
-        speaker.play_sound("meeting")
-        player = game.getPlayerById(data.get('player_id'))
-        game.start_meeting(player)
+    player_id = data.get('player_id')
+    game, room = get_game_by_player(player_id)
+    if not game or game.meeting:
+        return
+    speaker.play_sound("meeting")
+    player = game.getPlayerById(player_id)
+    game.start_meeting(player)
 
         # emit("meeting", broadcast=True)
         # game.meeting = True
@@ -163,56 +178,90 @@ def handleMeeting(data):
 
 @socketio.on("ready")
 def handleReady(data):
-    player = game.getPlayerById(data.get('player_id'))
+    player_id = data.get('player_id')
+    game, room = get_game_by_player(player_id)
+    if not game:
+        return
+    player = game.getPlayerById(player_id)
     player.ready = True
-    sendPlayerList()
+    sendPlayerList(game, room)
     game.try_start_voting() # only starts if all players are ready
 
 @socketio.on("vote")
 def handleVote(data):
-    voting_player = game.getPlayerById(data.get('player_id'))
-    voted_for = game.getPlayerById(data.get('votedFor'))
+    voting_player_id = data.get('player_id')
+    voted_for_id = data.get('votedFor')
+    game, _ = get_game_by_player(voting_player_id)
+    if not game:
+        return
+    voting_player = game.getPlayerById(voting_player_id)
+    voted_for = game.getPlayerById(voted_for_id)
     game.meeting.register_vote(voting_player, voted_for)
 
 @socketio.on("veto")
 def handleVote(data):
-    voting_player = game.getPlayerById(data.get('player_id'))
+    voting_player_id = data.get('player_id')
+    game, _ = get_game_by_player(voting_player_id)
+    if not game:
+        return
+    voting_player = game.getPlayerById(voting_player_id)
     game.meeting.register_vote(voting_player, veto=True)
         
 
 @socketio.on('end_meeting')
 def handleEndMeeting():
-    if game.meeting:
-        emit("end_meeting", broadcast=True)
-        game.meeting = False
-        logger.info("Meeting ended")
+    # Determine room by meeting owner's game
+    for room_id, game in rooms.items():
+        if game.meeting:
+            emit("end_meeting", room=room_id)
+            game.meeting = False
+            logger.info("Meeting ended")
 
 
 @socketio.on('meltdown')
-def handleMeltdown():
+def handleMeltdown(data):
+    player_id = data.get('player_id')
+    game, _ = get_game_by_player(player_id)
+    if not game:
+        return
     game.start_meltdown()
-    ## add card draw?
     logger.warning("Meltdown occurred.")
 
 @socketio.on("pin_entry")
 def handlePinEntry(data):
     logger.info("Pin entered")
+    player_id = data.get('player_id')
+    game, _ = get_game_by_player(player_id)
+    if not game:
+        return
     game.check_pin(data)
     logger.debug(f"Pin data: {data}")
 
 @socketio.on('player_dead')
 def handleDeath(data):
-    game.kill_player(data.get('player_id'))
+    player_id = data.get('player_id')
+    game, _ = get_game_by_player(player_id)
+    if not game:
+        return
+    game.kill_player(player_id)
 
 @socketio.on('reset')
-def reset_game():
+def reset_game(data):
+    room_id = data.get('room_id')
+    game = rooms.get(room_id)
+    if not game:
+        return
     for player in game.players:
         player.reset()
-    sendPlayerList()
+    sendPlayerList(game, room_id)
     logger.info("Game has been reset")
 
 @socketio.on('start_game')
 def handle_start(data):
+    room_id = data.get('room_id')
+    game = rooms.get(room_id)
+    if not game:
+        return
     if game.game_running:
         logger.warning("Start game attempted but game is already running")
         return
@@ -220,14 +269,12 @@ def handle_start(data):
     speaker.play_sound("theme")
     game.game_running = True
     game.assignRoles()
-    sendPlayerList('start_game')
-    emit("task_goal", game.taskGoal, broadcast=True)
+    sendPlayerList(game, room_id, 'start_game')
+    emit("task_goal", game.taskGoal, room=room_id)
     logger.info("Game started")
 
-    # Send a different task to each crewmate
     for player in game.players:
-        if not player.sus and len(taskHandler.tasks) > 0:
-            # gotta change this for impostor power ups 
+        if not player.sus and len(game.task_handler.tasks) > 0:
             player.task = game.getTask()
             emit("task", {"task": player.task}, to=player.sid)
             logger.debug(f"Assigned task to player {player.player_id}: {player.task}")
@@ -237,7 +284,14 @@ def handle_start(data):
 def handle_join(data):
     player_id = data.get('player_id')
     username = data.get('username')
+    room_id = data.get('room_id')
     sid = request.sid
+
+    game = rooms.get(room_id)
+    if not game:
+        emit('error', {'message': 'Room not found'}, to=sid)
+        return
+    join_room(room_id)
 
     if not username:
         emit('error', {'message': 'Username is required'}, to=sid)
@@ -247,12 +301,10 @@ def handle_join(data):
     if player_id:
         player = game.getPlayerById(player_id)
         if player:
-            # Player reconnected
             player.sid = sid
-            player.username = username  # Update username on reconnect
+            player.username = username
             logger.info(f"Player {player.username} (ID: {player.player_id}) reconnected with new SID: {sid}")
         else:
-            # Invalid player_id, create new player
             if game.game_running:
                 logger.warning(f"Join attempt with invalid player_id: {player_id} while game is running")
                 return
@@ -268,7 +320,8 @@ def handle_join(data):
         emit('player_id', {'player_id': player.player_id, 'pic': player.pic}, to=sid)
         logger.info(f"New player {username} joined with ID {player.player_id}")
 
-    sendPlayerList()
+    player_room[player.player_id] = room_id
+    sendPlayerList(game, room_id)
 
 @socketio.on('disconnect')
 def handle_disconnect():

--- a/server/assets/card.py
+++ b/server/assets/card.py
@@ -93,11 +93,12 @@ class Card:
 
 class CardDeck:
 
-    def __init__(self, locations, socket, game):
+    def __init__(self, locations, socket, game, room):
         self.discard = []
         self.active_cards = []
         self.socket = socket
         self.game = game
+        self.room = room
 
         self.cards = [# CHANGE THESE THEYDONT WORK
             Card('Self Report', 'Call a body found meeting', self), 
@@ -164,7 +165,7 @@ class CardDeck:
         for card in self.active_cards:
             output.append(card.export())
         print(output)
-        self.socket.emit('active_cards', output)
+        self.socket.emit('active_cards', output, room=self.room)
 
 
 

--- a/server/assets/game.py
+++ b/server/assets/game.py
@@ -13,7 +13,7 @@ from assets.utils import *
 
 class Game:
 
-    def __init__(self, socket, task_handler, speaker, task_ratio, meltdown_time, code_percent, locations, vote_time, card_draw_probability, numImposters, starting_cards):
+    def __init__(self, socket, task_handler, speaker, task_ratio, meltdown_time, code_percent, locations, vote_time, card_draw_probability, numImposters, starting_cards, room):
         self.players = []
         self.task_handler = task_handler
         self.crew_score = 0
@@ -28,10 +28,11 @@ class Game:
         self.completed_tasks = 0
         self.backgrounds = list(range(0, 16 + 1))  
         self.socket = socket
+        self.room = room
         self.end_state = None
         self.speaker = speaker
         self.denied_location = None
-        self.card_deck = CardDeck(locations, socket, self)
+        self.card_deck = CardDeck(locations, socket, self, room)
         self.active_cards = []
         self.card_draw_probability = card_draw_probability
 
@@ -44,7 +45,7 @@ class Game:
 
     def start_meltdown(self):
         self.speaker.loop_sound("meltdown", self.meltdown_time - self.meltdown_time_mod)
-        self.active_meltdown = Meltdown(self.players, self.meltdown_time - self.meltdown_time_mod, self.socket, self.speaker, self.code_percent)
+        self.active_meltdown = Meltdown(self.players, self.meltdown_time - self.meltdown_time_mod, self.socket, self.speaker, self.code_percent, self.room)
         self.meltdown_time_mod = 0
         for card in self.active_cards:
             if card.action == 'reduce_meltdown':
@@ -58,21 +59,21 @@ class Game:
     def meltdown(self): # call when meltdown fails
         self.active_meltdown = None
         self.end_state = "meltdown_fail"
-        self.socket.emit("end_game", self.end_state)
+        self.socket.emit("end_game", self.end_state, room=self.room)
 
         if self.speaker:
             self.speaker.play_sound("sus_victory")
 
     def emit_player_list(self):
         player_list = [player.to_json() for player in self.players]
-        self.socket.emit('game_data', {'action': 'player_list', 'list': player_list})
+        self.socket.emit('game_data', {'action': 'player_list', 'list': player_list}, room=self.room)
 
     def start_hack(self, duration):
         if self.active_hack > 0:
             return
         self.speaker.play_sound('hack')
         self.active_hack = duration
-        emit("hack", duration, broadcast=True)
+        emit("hack", duration, room=self.room)
 
         # Start a background thread to handle the countdown
         Thread(target=self._hack_countdown).start()
@@ -168,13 +169,13 @@ class Game:
         self.backgrounds = list(range(0, 16 + 1))  
         self.end_state = None
         self.denied_location = None
-        self.card_deck = CardDeck(self.locations)
+        self.card_deck = CardDeck(self.locations, self.socket, self, self.room)
         self.task_handler.reset()
 
     def start_meeting(self, player_who_started_it):
-        self.meeting = Meeting(self.vote_time, self.socket, player_who_started_it, self)
+        self.meeting = Meeting(self.vote_time, self.socket, player_who_started_it, self, self.room)
         self.speaker.play_sound('meeting')
-        self.socket.emit("meeting", self.meeting.to_json())
+        self.socket.emit("meeting", self.meeting.to_json(), room=self.room)
 
     def get_num_living_players(self):
         living_players = 0
@@ -210,7 +211,7 @@ class Game:
             if self.numCrew <= 0:
                 self.end_state = 'sus_victory'
                 self.speaker.play_sound('sus_victory')
-                self.socket.emit("end_game", self.end_state)
+                self.socket.emit("end_game", self.end_state, room=self.room)
                 return
     
             
@@ -219,7 +220,7 @@ class Game:
             if self.numImposters <= 0:
                 self.end_state = 'victory'
                 self.speaker.play_sound('crew_victory')
-                self.socket.emit("end_game", self.end_state)
+                self.socket.emit("end_game", self.end_state, room=self.room)
                 return
                 
         if self.meeting:

--- a/server/assets/meeting.py
+++ b/server/assets/meeting.py
@@ -6,13 +6,14 @@ from collections import Counter
 
 class Meeting:
 
-    def __init__(self, vote_time, socket, player_who_started_it, game):
+    def __init__(self, vote_time, socket, player_who_started_it, game, room):
         self.stage = 'waiting'
         self.time_left = vote_time
         self.socket = socket
         self.player_who_started_it = player_who_started_it
         self.game = game
         self.speaker = game.speaker
+        self.room = room
         self.votes = {} 
         self.veto_votes = set()
         self.reason = None
@@ -23,10 +24,10 @@ class Meeting:
     def start_voting(self):
         if self.game.get_num_living_players() <= 1:
             self.game.end_state = 'sus_victory'
-            self.socket.emit("end_game", self.game.end_state)
+            self.socket.emit("end_game", self.game.end_state, room=self.room)
             return
         self.stage = 'voting'
-        self.socket.emit("meeting", self.to_json())
+        self.socket.emit("meeting", self.to_json(), room=self.room)
         self.speaker.play_sound('hurry')
         Thread(target=self._vote_countdown).start()
     
@@ -79,7 +80,7 @@ class Meeting:
         veto_count = len(self.veto_votes)
 
         print(f"Vote Summary: {vote_summary}, Veto Votes: {veto_count}")
-        self.socket.emit("vote_update", {"votes": vote_summary, "vetoVotes": veto_count})
+        self.socket.emit("vote_update", {"votes": vote_summary, "vetoVotes": veto_count}, room=self.room)
 
     def check_veto_threshold(self):
         """
@@ -123,7 +124,7 @@ class Meeting:
             self.reason = 'veto'
 
             print("Meeting ended early due to veto threshold...")
-            self.socket.emit("meeting", self.to_json())
+            self.socket.emit("meeting", self.to_json(), room=self.room)
             self.speaker.play_sound('veto')
         else:
         # Regular meeting ending, determine who was voted out
@@ -138,7 +139,7 @@ class Meeting:
             self.reason = 'votes'
             self.votes = self.compute_vote_counts()
 
-            self.socket.emit("meeting", self.to_json())
+            self.socket.emit("meeting", self.to_json(), room=self.room)
 
             # draw cards for impostors
             self.game.drawCards(probability=self.game.card_draw_probability)

--- a/server/assets/meltdown.py
+++ b/server/assets/meltdown.py
@@ -2,7 +2,7 @@ import random
 import eventlet
 
 class Meltdown:
-    def __init__(self, players, time, socketio, speaker, code_percent):
+    def __init__(self, players, time, socketio, speaker, code_percent, room):
         self.players = players
         self.socketio = socketio
         self.time_left = time
@@ -14,11 +14,12 @@ class Meltdown:
         self.meltdown_active = True
         self.game = None
         self.speaker = speaker
+        self.room = room
 
     def start_countdown(self):
         """Starts the countdown timer."""
         print(f"Meltdown initiated! {self.time_left} seconds remaining.")
-        self.socketio.emit("codes_needed", self.codes_needed)
+        self.socketio.emit("codes_needed", self.codes_needed, room=self.room)
         self.distribute_codes()
         while self.time_left > 0:
             if self.codes_entered >= self.codes_needed:
@@ -26,7 +27,7 @@ class Meltdown:
                 return
             eventlet.sleep(1)  # Asynchronous delay
             self.time_left -= 1
-            self.socketio.emit('meltdown_update', self.time_left)
+            self.socketio.emit('meltdown_update', self.time_left, room=self.room)
 
         # If the countdown reaches 0 and the meltdown is still active
         if self.meltdown_active:
@@ -50,18 +51,18 @@ class Meltdown:
         except ValueError:
             # Handle the case where conversion fails
             print("Invalid PIN format. PIN should be a number.")
-            self.socketio.emit("code_incorrect")
+            self.socketio.emit("code_incorrect", room=self.room)
             return False
     
         if input_pin in self.valid_pins:
             print("Valid PIN entered!")
             self.valid_pins.remove(input_pin)
             self.codes_entered += 1
-            self.socketio.emit("code_correct", self.codes_needed - self.codes_entered)
+            self.socketio.emit("code_correct", self.codes_needed - self.codes_entered, room=self.room)
             return True
     
         print("Invalid PIN")
-        self.socketio.emit("code_incorrect")
+        self.socketio.emit("code_incorrect", room=self.room)
         return False
 
 
@@ -72,7 +73,7 @@ class Meltdown:
             if self.game:
                 self.game.active_meltdown = None
             self.speaker.play_sound("meltdown_over")
-            self.socketio.emit('meltdown_end')
+            self.socketio.emit('meltdown_end', room=self.room)
         else:
             print("Meltdown failed!")
             self.speaker.play_sound("meltdown_fail")

--- a/server/assets/utils.py
+++ b/server/assets/utils.py
@@ -19,7 +19,7 @@ def get_local_ip():
 def write_ip_to_file(ip_address):
     try:
         with open("../client/src/ENDPOINT.js", 'w') as file:
-            text = f"export const ENDPOINT = '{ip_address}'"
+            text = f"export const ENDPOINT = 'http://{ip_address}'"
             file.write(text)
         print(f"IP address '{ip_address}' has been written to '../client/src/ENDPOINT.js'.")
     except Exception as e:


### PR DESCRIPTION
## Summary
- implement room management on the server to allow multiple concurrent games
- scope socket events to rooms with new helpers and data structures
- extend game logic objects (Game, Meeting, Meltdown, CardDeck) with room awareness
- update client context to persist a room id and send it on reconnect
- enhance login page with room creation and join code entry
- update pages to include room id when starting games or triggering events

## Testing
- `npm test --silent --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ede1afa68832d996e570c1e969670